### PR TITLE
 Updated to compile with lens 2.9 (cabal install of bottle in a fresh haskell env fails otherwise)

### DIFF
--- a/Bottle.cabal
+++ b/Bottle.cabal
@@ -69,7 +69,7 @@ Library
                        StateVar,
                        TraceUtils,
                        hashable,
-                       lens >= 2.2,
+                       lens >= 2.9,
                        binary >= 0.5,
                        bytestring,
                        containers >= 0.4,


### PR DESCRIPTION
...n lens 2.7 or later, and bottle no longer compiles with these newer versions of lens)
