### PR TITLE
[WIP] Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+before_install:
+  # stack
+  - mkdir -p ~/.local/bin
+  - export PATH=~/.local/bin:$PATH
+  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.2.0/stack-0.1.2.0-x86_64-linux.gz | gunzip > ~/.local/bin/stack
+  - chmod a+x ~/.local/bin/stack
+
+install:
+  - stack setup
+
+script:
+  - stack test
+  
+cache:
+  directories:
+  - $HOME/.stack

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Lamdu
+# Lamdu [![Build Status](https://travis-ci.org/rvion/lamdu.svg)](https://travis-ci.org/rvion/lamdu)
 
 This project aims to create a "next-generation", "live programming" environment that radically improves the programming experience.
 


### PR DESCRIPTION
once https://github.com/Peaker/lamdu/pull/34 and https://github.com/Peaker/lamdu/pull/32 are merged, below travis config should work.

Before merging, the build status badge should be updated. 
For now, it points to `rvion/lamdu` instead of  `Peaker/lamdu`

for now, it fails with:

```
[...]
$ git clone --depth=50 --branch=add-travis-support git://github.com/rvion/lamdu.git rvion/lamdu
Cloning into 'rvion/lamdu'...
remote: Counting objects: 576, done.
remote: Compressing objects: 100% (309/309), done.
remote: Total 576 (delta 262), reused 366 (delta 229), pack-reused 0
Receiving objects: 100% (576/576), 626.07 KiB | 0 bytes/s, done.
Resolving deltas: 100% (262/262), done.
Checking connectivity... done.
$ cd rvion/lamdu
$ git checkout -qf 7b48c72bc3230a566f63a8a015c79f7a5ff41ab6
0.03s$ git submodule init
Submodule 'submodules/AlgoW' (git@github.com:Peaker/Algorithm-W-Step-By-Step.git) registered for path 'submodules/AlgoW'
3.42s$ git submodule update
Cloning into 'submodules/AlgoW'...
Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:Peaker/Algorithm-W-Step-By-Step.git' into submodule path 'submodules/AlgoW' failed
```
