### PR TITLE
Remove libglfw-dev from travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y zlib1g-dev libglew-dev libleveldb-dev libglfw-dev
+  - sudo apt-get install -y zlib1g-dev libglew-dev libleveldb-dev
   - sudo apt-get install -y libxrandr-dev libxi-dev libxcursor-dev libxinerama-dev
   - nvm install 7
   - mkdir -p ~/.local/bin


### PR DESCRIPTION
* The haskell GLFW-b package embeds the C GLFW package inside it