### PR TITLE
Tweak to ubuntu build instructions

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -41,14 +41,12 @@ Optional: Install NodeJS from node's apt repository:
 
 ```shell
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+NODE=`apt-cache policy nodejs | egrep -v "Installed" | egrep -o "(6\..*nodesource\w*)"`
+echo "About to install node version" $NODE
 ```
-...and check which version of node you're getting, with:
+... check it outputs something like `About to install node version 6.14.1-1nodesource1`, and then run:
 ```shell
-apt-cache policy nodejs
-```
-...and substitute appropriately for `6.14.1-1nodesource1` in the following command:
-```shell
-sudo apt-get install -y nodejs=6.14.1-1nodesource1
+sudo apt-get install -y nodejs=$NODE
 ```
 Run `node -v` to check you've ended up with a 6.x release rather than 8.x or later.
 

--- a/doc/Build.md
+++ b/doc/Build.md
@@ -41,10 +41,18 @@ Optional: Install NodeJS from node's apt repository:
 
 ```shell
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-sudo apt-get install -y nodejs
 ```
+...and check which version of node you're getting, with:
+```shell
+apt-cache policy nodejs
+```
+...and substitute appropriately for `6.14.1-1nodesource1` in the following command:
+```shell
+sudo apt-get install -y nodejs=6.14.1-1nodesource1
+```
+Run `node -v` to check you've ended up with a 6.x release rather than 8.x or later.
 
-requires [stack](https://github.com/commercialhaskell/stack/releases) (version 1.6.1 or above)
+Then to install lamdu - requires [stack](https://github.com/commercialhaskell/stack/releases) (version 1.6.1 or above):
 
 ```shell
 sudo apt-get update -qq


### PR DESCRIPTION
When I followed the previous instructions, I ended up with node 8.x installed, rather than node 6.x, because apt was already aware of an 8.x series release.

I propose tweaking the instructions to get the reader to find the specific node version they want to install.

Your new video is awesome by the way!  Looking forward to playing with lamdu.