### PR TITLE
fix dependency hash in nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let config = {
                         language-ecmascript = self.callHackageDirect
                             { pkg = "language-ecmascript";
                               ver = "0.19.1.0";
-                              sha256 = "lieoyqzd7hsidcmd3y4akyskvahcacphrdbur7v4ponezu74mvha";
+                              sha256 = "0mbwz6m9666l7kmg934205gxw1627s3yzk4w9zkpr0irx7xqml5i";
                             } {};
                         testing-feat = self.callHackage "testing-feat" "1.1.0.0" {};
                         # aeson-diff = pkgs.haskell.lib.doJailbreak (self.callHackage "aeson-diff" "1.1.0.5" {});


### PR DESCRIPTION
Hi there! After long search I finally found this project again after seeing a highly inspiring demo in 2015. I am greatly impressed how far it has progressed since, awesome work!

I was even more amazed when installation instructions mentioned `nix` - finally a visionary piece of software one can try out by running a single command.

This change makes the `nix` build work again by replacing a dependency hash. Note though that this is just what `nix` found to be the actual value in the error message. While I know my way around `nix`, I have no experience with building Haskell projects, therefore I don't know how that value is produced for a fixed-output derivation of a Cabal package. It certainly is not the `sha256` of the tarball as presented by `nix-prefetch-url`. Note also that to obtain the actual value one has to change the existing one to something else. Otherwise you get an unhelpful output:

```log
invalid base-32 hash 'lieoyqzd7hsidcmd3y4akyskvahcacphrdbur7v4ponezu74mvha'
```