### PR TITLE
Use constraints wildcards to reduce boilerplate across GUI code

### DIFF
--- a/Lamdu.cabal
+++ b/Lamdu.cabal
@@ -73,7 +73,7 @@ Executable lamdu
   default-extensions: NoImplicitPrelude, OverloadedStrings, PartialTypeSignatures, LambdaCase, DeriveTraversable, DeriveGeneric, DeriveAnyClass, DerivingStrategies, FlexibleContexts
   default-language: Haskell2010
   build-depends: Lamdu, base, directory, process, template-haskell, time, base-compat
-  ghc-options: -rtsopts -with-rtsopts=-A128M -O2 -Wall -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints -threaded
+  ghc-options: -rtsopts -with-rtsopts=-A128M -O2 -Wall -Wno-partial-type-signatures -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints -threaded
   ghc-prof-options: -fprof-auto -fprof-cafs -rtsopts
   if flag(ekg)
     ghc-options: -with-rtsopts=-T
@@ -125,7 +125,7 @@ Test-Suite Tests
     , Lamdu, lamdu-calculus, momentu, hypertypes, nodejs-exec
     , aeson, aeson-pretty, bytestring, containers, directory, filepath, GLFW-b
     , lens, List, mtl, pretty, process, random, text, uuid-types, Cabal
-  ghc-options: -O0 -Wall -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints -threaded
+  ghc-options: -O0 -Wall -Wno-partial-type-signatures -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints -threaded
   ghc-prof-options: -fprof-auto -fprof-cafs -rtsopts
 
 Library
@@ -409,7 +409,7 @@ Library
 
   other-modules:    Paths_Lamdu
 
-  ghc-options:         -O2 -Wall -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints
+  ghc-options:         -O2 -Wall -Wno-partial-type-signatures -Widentities -Wimplicit-prelude -Wmissing-home-modules -Wincomplete-patterns -Wnoncanonical-monad-instances -Wsemigroup -Wincomplete-record-updates -Wredundant-constraints
   ghc-prof-options:    -fprof-auto -fprof-cafs
   if flag(ekg)
     cpp-options: -DWITH_EKG

--- a/src/Lamdu/Editor.hs
+++ b/src/Lamdu/Editor.hs
@@ -223,7 +223,6 @@ runMainLoop ekg stateStorage subpixel win mainLoop configSampler
             }
 
 makeMainGui ::
-    HasCallStack =>
     [TitledSelection Folder.Theme] -> [TitledSelection Folder.Language] ->
     (forall a. T DbLayout.DbM a -> IO a) ->
     Env -> GUIMain.Model Env DbLayout.ViewM ->

--- a/src/Lamdu/GUI/CodeEdit.hs
+++ b/src/Lamdu/GUI/CodeEdit.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns, DisambiguateRecordFields #-}
+
 module Lamdu.GUI.CodeEdit
     ( make
     , Model
@@ -20,26 +21,17 @@ import qualified GUI.Momentu.Align as Align
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Hover as Hover
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.State as GuiState
 import           GUI.Momentu.Widget (Widget)
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Choice as Choice
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Menu as Menu
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import           Hyper.Type.AST.Scheme (Scheme(..), QVars(..))
 import qualified Lamdu.Builtins.Anchors as Builtins
 import qualified Lamdu.Calc.Term as V
 import qualified Lamdu.Calc.Type as T
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Data.Anchors as Anchors
 import           Lamdu.Data.Definition (Definition(..))
 import qualified Lamdu.Data.Definition as Definition
@@ -60,17 +52,11 @@ import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.TagPane as TagPaneEdit
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import qualified Lamdu.GUI.Types as ExprGui
-import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
 import qualified Lamdu.I18N.Collaboration as Texts
 import qualified Lamdu.I18N.Definitions as Texts
-import           Lamdu.I18N.LangId (LangId)
-import qualified Lamdu.I18N.Language as Language
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name)
-import           Lamdu.Settings (Settings)
-import           Lamdu.Style (HasStyle)
 import qualified Lamdu.Sugar.Types as Sugar
 import           Revision.Deltum.Transaction (Transaction)
 
@@ -100,17 +86,7 @@ type Model env m =
     )
 
 make ::
-    ( Has Config env
-    , Has Theme env, GuiState.HasState env
-    , Spacer.HasStdSpacing env
-    , Has (ExportActions m) env
-    , Has Settings env, HasStyle env
-    , Has Hover.Style env, Has Menu.Config env
-    , Has SearchMenu.TermStyle env
-    , Element.HasAnimIdPrefix env
-    , Language.HasLanguage env
-    , Monad m
-    ) =>
+    _ =>
     Anchors.CodeAnchors m -> Anchors.GuiAnchors (T m) (T m) -> Widget.R -> Model env m ->
     ReaderT env (OnceT (T m)) (StatusBar.StatusWidget (IOTrans m), Widget (IOTrans m))
 make cp gp width mkWorkArea =
@@ -157,10 +133,7 @@ make cp gp width mkWorkArea =
             }
 
 exportPaneEventMap ::
-    ( Functor m
-    , Has Config env
-    , Has (Texts.Collaboration Text) env
-    ) =>
+    _ =>
     env -> ExportActions m -> Sugar.PaneBody v name i o dummy ->
     EventMap (IOTrans m GuiState.Update)
 exportPaneEventMap env theExportActions paneBody =
@@ -176,15 +149,7 @@ exportPaneEventMap env theExportActions paneBody =
             & E.keysEventMap exportKeys
             (E.toDoc (env ^. has) [Texts.collaboration, docLens])
 
-makePaneBodyEdit ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env, TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env, Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env, Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env, Has (Texts.Navigation Text) env
-    , Has LangId env, Has (Map LangId Text) env
-    ) =>
-    ExprGui.Top Sugar.Pane i o -> GuiM env i o (Responsive o)
+makePaneBodyEdit :: _ => ExprGui.Top Sugar.Pane i o -> GuiM env i o (Responsive o)
 makePaneBodyEdit pane =
     case pane ^. Sugar.paneBody of
     Sugar.PaneTag tag -> TagPaneEdit.make tag <&> Responsive.fromWidget
@@ -205,7 +170,7 @@ makePaneBodyEdit pane =
             DefinitionEdit.make eventMap def
 
 makePaneEdit ::
-    (Monad m, Language.HasLanguage env) =>
+    _ =>
     ExportActions m ->
     ExprGui.Top Sugar.Pane (OnceT (T m)) (T m) ->
     GuiM env (OnceT (T m)) (T m) (Responsive (IOTrans m))
@@ -255,17 +220,12 @@ makeNewDefinition cp =
             & DataOps.newPublicDefinitionWithPane cp
     <&> WidgetIds.fromIRef
 
-newDefinitionDoc ::
-    ( MonadReader env m
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) => m E.Doc
+newDefinitionDoc :: _ => m E.Doc
 newDefinitionDoc =
     Lens.view id
     <&> (`E.toDoc` [has . MomentuTexts.edit, has . Texts.new])
 
-makeNewDefinitionButton ::
-    (Monad m, Language.HasLanguage env) =>
-    Anchors.CodeAnchors m -> GuiM env (OnceT (T m)) (T m) (Widget (T m))
+makeNewDefinitionButton :: _ => Anchors.CodeAnchors m -> GuiM env (OnceT (T m)) (T m) (Widget (T m))
 makeNewDefinitionButton cp =
     do
         newDefId <- Element.subAnimId ?? ["New definition"] <&> Widget.Id
@@ -282,7 +242,7 @@ jumpBack gp =
     (j:js) -> j <$ Property.setP (Anchors.preJumps gp) js & Just
 
 panesEventMap ::
-    (Monad m, Language.HasLanguage env) =>
+    _ =>
     ExportActions m -> Anchors.CodeAnchors m -> Anchors.GuiAnchors (T m) (T m) ->
     Sugar.VarInfo -> GuiM env (OnceT (T m)) (T m) (EventMap (IOTrans m GuiState.Update))
 panesEventMap theExportActions cp gp replVarInfo =

--- a/src/Lamdu/GUI/CodeEdit/GotoDefinition.hs
+++ b/src/Lamdu/GUI/CodeEdit/GotoDefinition.hs
@@ -9,16 +9,9 @@ import qualified Data.ByteString.Char8 as BS8
 import           Data.MRUMemo (memo)
 import qualified Data.Text as Text
 import qualified GUI.Momentu as M
-import qualified GUI.Momentu.Direction as Dir
-import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
-import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
-import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import           Lamdu.Fuzzy (Fuzzy)
@@ -26,8 +19,6 @@ import qualified Lamdu.Fuzzy as Fuzzy
 import qualified Lamdu.GUI.Expr.GetVarEdit as GetVarEdit
 import qualified Lamdu.GUI.StatusBar.Common as StatusBar
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Name as Texts
-import           Lamdu.I18N.Navigation (Navigation)
 import qualified Lamdu.I18N.Navigation as Navigation
 import           Lamdu.Name (Name)
 import qualified Lamdu.Name as Name
@@ -45,7 +36,7 @@ allowSearchTerm = Name.isValidText
 fuzzyMaker :: [(Text, Int)] -> Fuzzy (Set Int)
 fuzzyMaker = memo Fuzzy.make
 
-nameSearchTerm :: (MonadReader env m, Has (Texts.Name Text) env) => Name -> m Text
+nameSearchTerm :: _ => Name -> m Text
 nameSearchTerm name =
     Name.visible name <&>
     \(Name.TagText text textCol, tagCol) ->
@@ -56,12 +47,7 @@ nameSearchTerm name =
         collisionText Name.UnknownCollision = "?"
 
 makeOptions ::
-    ( MonadReader env m, Has Theme env, Applicative o
-    , Has TextView.Style env, M.HasAnimIdPrefix env, M.HasCursor env
-    , Has (Navigation Text) env, Has (Texts.Name Text) env, Has Dir.Layout env
-    ) =>
-    m [Sugar.NameRef Name o] ->
-    SearchMenu.ResultsContext -> m (Menu.OptionList (Menu.Option m o))
+    _ => m [Sugar.NameRef Name o] -> SearchMenu.ResultsContext -> m (Menu.OptionList (Menu.Option m o))
 makeOptions readGlobals (SearchMenu.ResultsContext searchTerm prefix)
     | Text.null searchTerm = pure Menu.TooMany
     | otherwise =
@@ -103,15 +89,7 @@ makeOptions readGlobals (SearchMenu.ResultsContext searchTerm prefix)
             }
         toPickResult x = Menu.PickResult x (Just x)
 
-make ::
-    ( MonadReader env m, Applicative o
-    , Has Theme env, M.HasAnimIdPrefix env
-    , Has Menu.Config env, Has Hover.Style env, GuiState.HasState env
-    , Has SearchMenu.TermStyle env, Has (Navigation Text) env
-    , Glue.HasTexts env, TextEdit.Deps env
-    , SearchMenu.HasTexts env, Has (Texts.Name Text) env
-    ) =>
-    m [Sugar.NameRef Name o] -> m (StatusBar.StatusWidget o)
+make :: _ => m [Sugar.NameRef Name o] -> m (StatusBar.StatusWidget o)
 make readGlobals =
     do
         goto <- Lens.view (has . Navigation.goto)

--- a/src/Lamdu/GUI/DefinitionEdit.hs
+++ b/src/Lamdu/GUI/DefinitionEdit.hs
@@ -5,25 +5,17 @@ module Lamdu.GUI.DefinitionEdit
 import qualified Control.Lens as Lens
 import qualified Control.Monad.Reader as Reader
 import qualified Data.Property as Property
-import           GUI.Momentu.Align (WithTextPos, TextWidget)
-import qualified GUI.Momentu.Align as Align
+import qualified GUI.Momentu as M
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import           GUI.Momentu.Glue ((/-/), (/|/))
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.Rect (Rect(..))
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.State as GuiState
-import           GUI.Momentu.View (View)
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Choice as Choice
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import qualified Lamdu.GUI.Expr.AssignmentEdit as AssignmentEdit
 import qualified Lamdu.GUI.Expr.BuiltinEdit as BuiltinEdit
@@ -33,22 +25,13 @@ import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.TypeView as TypeView
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
 import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-undeleteButton ::
-    ( Monad i, Monad o
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.Definitions Text) env
-    ) =>
-    o Widget.Id -> GuiM env i o (TextWidget o)
+undeleteButton :: _ => o Widget.Id -> GuiM env i o (M.TextWidget o)
 undeleteButton undelete =
     do
         actionId <- Element.subAnimId ?? ["Undelete"] <&> Widget.Id
@@ -63,17 +46,7 @@ undeleteButton undelete =
             doc undelete
 
 makeExprDefinition ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     ExprGui.Top Sugar.Definition i o ->
     ExprGui.Top Sugar.DefinitionExpression i o ->
     GuiM env i o (Responsive o)
@@ -87,24 +60,16 @@ makeExprDefinition def bodyExpr =
         myId = def ^. Sugar.drEntityId & WidgetIds.fromEntityId
 
 makeBuiltinDefinition ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Sugar.Definition v Name i o (Sugar.Payload v Name i o, ExprGui.GuiPayload) ->
     Sugar.DefinitionBuiltin Name o ->
-    GuiM env i o (TextWidget o)
+    GuiM env i o (M.TextWidget o)
 makeBuiltinDefinition def builtin =
     TagEdit.makeBinderTagEdit TextColors.definitionColor name
-    /|/ Label.make " = "
-    /|/ BuiltinEdit.make builtin myId
-    /-/ ( topLevelSchemeTypeView (builtin ^. Sugar.biType)
-            & Reader.local (Element.animIdPrefix .~ animId ++ ["builtinType"])
+    M./|/ Label.make " = "
+    M./|/ BuiltinEdit.make builtin myId
+    M./-/ ( topLevelSchemeTypeView (builtin ^. Sugar.biType)
+            & Reader.local (M.animIdPrefix .~ animId ++ ["builtinType"])
         )
     where
         name = def ^. Sugar.drName
@@ -122,20 +87,7 @@ wholeFocused size f =
     }
 
 make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    EventMap (o GuiState.Update) ->
-    ExprGui.Top Sugar.Definition i o ->
-    GuiM env i o (Responsive o)
+    _ => EventMap (o GuiState.Update) -> ExprGui.Top Sugar.Definition i o -> GuiM env i o (Responsive o)
 make defEventMap def =
     do
         defGui <-
@@ -155,21 +107,15 @@ make defEventMap def =
                     style <- Styled.deletedDef
                     let defGuiStyled =
                             defGui
-                            & Responsive.alignedWidget . Align.tValue .> Widget.wFocused %@~ wholeFocused
+                            & Responsive.alignedWidget . M.tValue .> Widget.wFocused %@~ wholeFocused
                             & style
                     Responsive.vbox ?? [buttonGui, defGuiStyled]
-    & Reader.local (Element.animIdPrefix .~ Widget.toAnimId myId)
+    & Reader.local (M.animIdPrefix .~ Widget.toAnimId myId)
     where
         defStateProp = def ^. Sugar.drDefinitionState
         myId = def ^. Sugar.drEntityId & WidgetIds.fromEntityId
 
-topLevelSchemeTypeView ::
-    ( Monad i
-    , Has (Texts.Code Text) env
-    , Has (Texts.Name Text) env
-    , Glue.HasTexts env
-    ) =>
-    Sugar.Scheme Name -> GuiM env i o (WithTextPos View)
+topLevelSchemeTypeView :: _ => Sugar.Scheme Name -> GuiM env i o (M.WithTextPos M.View)
 topLevelSchemeTypeView scheme =
     -- At the definition-level, Schemes can be shown as ordinary
     -- types to avoid confusing forall's:

--- a/src/Lamdu/GUI/Expr.hs
+++ b/src/Lamdu/GUI/Expr.hs
@@ -8,10 +8,7 @@ import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.GUI.Expr.ApplyEdit as ApplyEdit
 import qualified Lamdu.GUI.Expr.FragmentEdit as FragmentEdit
 import qualified Lamdu.GUI.Expr.GetVarEdit as GetVarEdit
@@ -25,27 +22,11 @@ import qualified Lamdu.GUI.Expr.RecordEdit as RecordEdit
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
-    ExprGui.Expr Sugar.Term i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Term i o -> GuiM env i o (Responsive o)
 make e =
     makeEditor e & assignCursor
     where
@@ -64,18 +45,7 @@ placeHolder pl =
     <*> Label.make "★"
     <&> Responsive.fromWithTextPos
 
-makeEditor ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
-    ExprGui.Expr Sugar.Term i o -> GuiM env i o (Responsive o)
+makeEditor :: _ => ExprGui.Expr Sugar.Term i o -> GuiM env i o (Responsive o)
 makeEditor (Ann (Const pl) body) =
     case body of
     Sugar.BodyLabeledApply x -> editor pl x ApplyEdit.makeLabeled

--- a/src/Lamdu/GUI/Expr/ApplyEdit.hs
+++ b/src/Lamdu/GUI/Expr/ApplyEdit.hs
@@ -4,17 +4,13 @@ module Lamdu.GUI.Expr.ApplyEdit
 
 import qualified Control.Lens as Lens
 import           GUI.Momentu ((/|/))
-import qualified GUI.Momentu.Glue as Glue
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Responsive.Expression as ResponsiveExpr
 import qualified GUI.Momentu.Responsive.Options as Options
 import           GUI.Momentu.Responsive.TaggedList (TaggedItem(..), taggedList)
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.GUI.Expr.CaseEdit as CaseEdit
 import qualified Lamdu.GUI.Expr.EventMap as ExprEventMap
 import qualified Lamdu.GUI.Expr.GetFieldEdit as GetFieldEdit
@@ -29,25 +25,13 @@ import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrap, stdWrapParentExpr)
 import qualified Lamdu.GUI.Wrap as Wrap
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
 makeFunc ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     GetVarEdit.Role ->
     Annotated (ExprGui.Payload i o) # Const (Sugar.BinderVarRef Name o) ->
     GuiM env i o (Responsive o)
@@ -59,16 +43,7 @@ makeFunc role func =
         pl = func ^. annotation
         myId = WidgetIds.fromExprPayload (pl ^. _1)
 
-makeLabeled ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Expr Sugar.LabeledApply i o -> GuiM env i o (Responsive o)
+makeLabeled :: _ => ExprGui.Expr Sugar.LabeledApply i o -> GuiM env i o (Responsive o)
 makeLabeled (Ann (Const pl) apply) =
     ExprEventMap.add ExprEventMap.defaultOptions pl <*>
     ( Wrap.parentDelegator (WidgetIds.fromExprPayload (pl ^. _1)) <*>
@@ -92,9 +67,7 @@ makeLabeled (Ann (Const pl) apply) =
             addArgs apply x
         func = apply ^. Sugar.aFunc
 
-makeArgRow ::
-    (Monad i, Glue.HasTexts env, Has (Texts.Name Text) env) =>
-    ExprGui.Body Sugar.AnnotatedArg i o -> GuiM env i o (TaggedItem o)
+makeArgRow :: _ => ExprGui.Body Sugar.AnnotatedArg i o -> GuiM env i o (TaggedItem o)
 makeArgRow arg =
     do
         expr <- GuiM.makeSubexpression (arg ^. Sugar.aaExpr)
@@ -108,14 +81,7 @@ makeArgRow arg =
             , _tagPost = Nothing
             }
 
-addArgs ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , Has (Texts.Definitions Text) env, Has (Texts.Navigation Text) env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    ) =>
-    ExprGui.Body Sugar.LabeledApply i o -> Responsive o -> GuiM env i o (Responsive o)
+addArgs :: _ => ExprGui.Body Sugar.LabeledApply i o -> Responsive o -> GuiM env i o (Responsive o)
 addArgs apply funcRow =
     do
         argRows <-
@@ -134,14 +100,7 @@ addArgs apply funcRow =
                 <*> (Responsive.vboxSpaced ?? (funcRow : extraRows))
 
 makeSimple ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Annotated (ExprGui.Payload i o)
         # Sugar.App (Sugar.Term (Sugar.Annotation (Sugar.EvaluationScopes Name i) Name) Name i o) ->
     GuiM env i o (Responsive o)
@@ -152,19 +111,7 @@ makeSimple (Ann (Const pl) (Sugar.App func arg)) =
     , GuiM.makeSubexpression arg
     ] & stdWrapParentExpr pl
 
-makePostfix ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , Has (TextEdit.Texts Text) env
-    , SearchMenu.HasTexts env
-    ) =>
-    ExprGui.Expr Sugar.PostfixApply i o ->
-    GuiM env i o (Responsive o)
+makePostfix :: _ => ExprGui.Expr Sugar.PostfixApply i o -> GuiM env i o (Responsive o)
 makePostfix (Ann (Const pl) (Sugar.PostfixApply arg func)) =
     (ResponsiveExpr.boxSpacedMDisamb ?? ExprGui.mParensId pl)
     <*> sequenceA
@@ -172,19 +119,7 @@ makePostfix (Ann (Const pl) (Sugar.PostfixApply arg func)) =
     , makePostfixFunc func
     ] & stdWrapParentExpr pl
 
-makePostfixFunc ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , Has (TextEdit.Texts Text) env
-    , SearchMenu.HasTexts env
-    ) =>
-    ExprGui.Expr Sugar.PostfixFunc i o ->
-    GuiM env i o (Responsive o)
+makePostfixFunc :: _ => ExprGui.Expr Sugar.PostfixFunc i o -> GuiM env i o (Responsive o)
 makePostfixFunc (Ann (Const pl) x) =
     (ResponsiveExpr.boxSpacedMDisamb ?? ExprGui.mParensId pl) <*>
     ( case x of

--- a/src/Lamdu/GUI/Expr/AssignmentEdit.hs
+++ b/src/Lamdu/GUI/Expr/AssignmentEdit.hs
@@ -13,7 +13,6 @@ import qualified Data.Map as Map
 import           Data.Property (Property)
 import qualified Data.Property as Property
 import qualified GUI.Momentu as M
-import qualified GUI.Momentu.Direction as Dir
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
 import qualified GUI.Momentu.FocusDirection as Direction
@@ -28,15 +27,10 @@ import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Responsive.Options as Options
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Choice as Choice
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextView as TextView
 import qualified Lamdu.Annotations as Annotations
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.Config.Theme.TextColors (TextColors)
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -54,8 +48,6 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrap)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Settings as Settings
@@ -118,10 +110,7 @@ mkChosenScopeCursor func =
             <&> (>>= scopeCursor mChosenScope)
 
 makeScopeEventMap ::
-    ( Has (Texts.Navigation Text) env
-    , Has (Texts.CodeUI Text) env
-    , Functor o
-    ) =>
+    _ =>
     env -> [MetaKey] -> [MetaKey] -> ScopeCursor -> (Sugar.BinderParamScopeId -> o ()) ->
     EventMap (o M.Update)
 makeScopeEventMap env prevKey nextKey cursor setter =
@@ -140,12 +129,7 @@ makeScopeEventMap env prevKey nextKey cursor setter =
             , has . x
             ]
 
-makeScopeNavArrow ::
-    ( MonadReader env m, Has Theme env, Has TextView.Style env
-    , M.HasAnimIdPrefix env, Applicative o
-    , Has Dir.Layout env
-    ) =>
-    (w -> o M.Update) -> Text -> Maybe w -> m (M.TextWidget o)
+makeScopeNavArrow :: _ => (w -> o M.Update) -> Text -> Maybe w -> m (M.TextWidget o)
 makeScopeNavArrow setScope arrowText mScopeId =
     do
         theme <- Lens.view has
@@ -172,11 +156,7 @@ makeScopeNavArrow setScope arrowText mScopeId =
                     | point `Rect.isWithin` r = res action
                 validate _ _ = res (pure mempty)
 
-blockEventMap ::
-    ( Has (Texts.Navigation Text) env
-    , Has (MomentuTexts.Texts Text) env
-    , Applicative m
-    ) => env -> EventMap (m M.Update)
+blockEventMap :: _ => env -> EventMap (m M.Update)
 blockEventMap env =
     pure mempty
     & E.keyPresses (dirKeys <&> toModKey)
@@ -188,11 +168,7 @@ blockEventMap env =
         dirKeys = [MetaKey.Key'Left, MetaKey.Key'Right] <&> MetaKey noMods
 
 makeScopeNavEdit ::
-    ( Monad i, Applicative o
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.CodeUI Text) env
-    , Glue.HasTexts env
-    ) =>
+    _ =>
     Sugar.Function v name i o expr -> Widget.Id -> ScopeCursor ->
     GuiM env i o
     ( EventMap (o M.Update)
@@ -262,14 +238,7 @@ namedParamEditInfo widgetId actions nameEdit =
     }
 
 makeParamsEdit ::
-    ( Monad i, Monad o
-    , Has (TextEdit.Texts Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.Navigation Text) env
-    , Glue.HasTexts env, SearchMenu.HasTexts env
-    ) =>
+    _ =>
     Annotation.EvalAnnotationOptions ->
     Widget.Id -> Widget.Id -> Widget.Id ->
     Sugar.BinderParams (Sugar.Annotation (Sugar.EvaluationScopes Name i) Name) Name i o ->
@@ -305,15 +274,7 @@ makeParamsEdit annotationOpts delVarBackwardsId lhsId rhsId params =
                 mkParam (prevId, nextId, param) = ParamEdit.make annotationOpts prevId nextId param
 
 makeMParamsEdit ::
-    ( Monad i, Monad o
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
+    _ =>
     CurAndPrev (Maybe ScopeCursor) -> IsScopeNavFocused ->
     Widget.Id -> Widget.Id ->
     Widget.Id ->
@@ -364,15 +325,7 @@ makeMParamsEdit mScopeCursor isScopeNavFocused delVarBackwardsId myId bodyId add
             & Annotation.WithNeighbouringEvalAnnotations
 
 makeFunctionParts ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Sugar.FuncApplyLimit -> ExprGui.Expr Sugar.Function i o -> Widget.Id -> GuiM env i o (Parts i o)
 makeFunctionParts funcApplyLimit (Ann (Const pl) func) delVarBackwardsId =
     do
@@ -414,15 +367,7 @@ makeFunctionParts funcApplyLimit (Ann (Const pl) func) delVarBackwardsId =
         bodyId = func ^. Sugar.fBody . annotation . _1 & WidgetIds.fromExprPayload
 
 makePlainParts ::
-    ( Monad i, Monad o
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
+    _ =>
     ExprGui.Expr Sugar.AssignPlain i o -> Widget.Id -> GuiM env i o (Parts i o)
 makePlainParts (Ann (Const pl) assignPlain) delVarBackwardsId =
     do
@@ -437,27 +382,14 @@ makePlainParts (Ann (Const pl) assignPlain) delVarBackwardsId =
         myId = WidgetIds.fromExprPayload (pl ^. _1)
 
 makeParts ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Sugar.FuncApplyLimit -> ExprGui.Expr Sugar.Assignment i o -> Widget.Id -> GuiM env i o (Parts i o)
 makeParts funcApplyLimit (Ann (Const pl) assignmentBody) =
     case assignmentBody of
     Sugar.BodyFunction x -> makeFunctionParts funcApplyLimit (Ann (Const pl) x)
     Sugar.BodyPlain x -> makePlainParts (Ann (Const pl) x)
 
-makeJumpToRhs ::
-    ( Monad i, Monad o
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Widget.Id -> GuiM env i o (EventMap (o M.Update))
+makeJumpToRhs :: _ => Widget.Id -> GuiM env i o (EventMap (o M.Update))
 makeJumpToRhs rhsId =
     do
         env <- Lens.view id
@@ -472,17 +404,7 @@ makeJumpToRhs rhsId =
             "="
 
 make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Maybe (i (Property o Meta.PresentationMode)) ->
     Sugar.TagRef Name i o -> Lens.ALens' TextColors M.Color ->
     ExprGui.Expr Sugar.Assignment i o ->

--- a/src/Lamdu/GUI/Expr/BinderEdit.hs
+++ b/src/Lamdu/GUI/Expr/BinderEdit.hs
@@ -10,11 +10,7 @@ import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Choice as Choice
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.Config as Config
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -28,28 +24,13 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrapParentExpr)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as CodeUI
-import qualified Lamdu.I18N.CodeUI as Texts
 import qualified Lamdu.I18N.Definitions as Definitions
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-makeLetEdit ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Body Sugar.Let i o -> GuiM env i o (Responsive o)
+makeLetEdit :: _ => ExprGui.Body Sugar.Let i o -> GuiM env i o (Responsive o)
 makeLetEdit item =
     do
         env <- Lens.view id
@@ -90,19 +71,7 @@ makeLetEdit item =
         bodyId = item ^. Sugar.lBody . annotation . _1 & WidgetIds.fromExprPayload
         binder = item ^. Sugar.lValue
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Expr Sugar.Binder i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Binder i o -> GuiM env i o (Responsive o)
 make (Ann (Const pl) (Sugar.BinderTerm assignmentBody)) =
     Ann (Const pl) assignmentBody & GuiM.makeSubexpression
 make (Ann (Const pl) (Sugar.BinderLet l)) =

--- a/src/Lamdu/GUI/Expr/BuiltinEdit.hs
+++ b/src/Lamdu/GUI/Expr/BuiltinEdit.hs
@@ -8,7 +8,6 @@ import           Data.Property (Property(..))
 import qualified Data.Text as Text
 import qualified GUI.Momentu as M
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.MetaKey (MetaKey(..), noMods)
 import qualified GUI.Momentu.MetaKey as MetaKey
@@ -19,7 +18,6 @@ import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextEdit.Property as TextEdits
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import qualified Lamdu.Data.Definition as Definition
@@ -28,9 +26,7 @@ import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-builtinFDConfig ::
-    (Has (Texts.CodeUI Text) env, Has (MomentuTexts.Texts Text) env) =>
-    env -> FocusDelegator.Config
+builtinFDConfig :: _ => env -> FocusDelegator.Config
 builtinFDConfig env = FocusDelegator.Config
     { FocusDelegator.focusChildKeys = [MetaKey noMods MetaKey.Key'Enter]
     , FocusDelegator.focusChildDoc = doc Texts.changeImportedName
@@ -47,11 +43,7 @@ builtinFFIName :: Widget.Id -> Widget.Id
 builtinFFIName = flip Widget.joinId ["FFIName"]
 
 makeNamePartEditor ::
-    ( Applicative f, MonadReader env m, GuiState.HasCursor env
-    , TextEdit.Deps env, Has (Texts.CodeUI Text) env
-    ) =>
-    M.Color -> Text -> (Text -> f ()) -> Widget.Id ->
-    m (M.TextWidget f)
+    _ => M.Color -> Text -> (Text -> f ()) -> Widget.Id -> m (M.TextWidget f)
 makeNamePartEditor color namePartStr setter myId =
     (FocusDelegator.make
         <*> (Lens.view id <&> builtinFDConfig)
@@ -68,13 +60,7 @@ makeNamePartEditor color namePartStr setter myId =
             , TextEdit._focused = ""
             }
 
-make ::
-    ( MonadReader env f, Monad o, Has Theme env, GuiState.HasCursor env
-    , TextEdit.Deps env, M.HasAnimIdPrefix env
-    , Has (Texts.CodeUI Text) env, Glue.HasTexts env
-    ) =>
-    Sugar.DefinitionBuiltin name o -> Widget.Id ->
-    f (M.TextWidget o)
+make :: _ => Sugar.DefinitionBuiltin name o -> Widget.Id -> f (M.TextWidget o)
 make def myId =
     do
         colors <- Lens.view (has . Theme.textColors)

--- a/src/Lamdu/GUI/Expr/CaseEdit.hs
+++ b/src/Lamdu/GUI/Expr/CaseEdit.hs
@@ -17,13 +17,9 @@ import qualified GUI.Momentu.State as GuiState
 import           GUI.Momentu.View (View)
 import qualified GUI.Momentu.View as View
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.Menu as Menu
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.Config.Theme.TextColors (TextColors)
@@ -41,19 +37,12 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import qualified Lamdu.GUI.Wrap as Wrap
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-doc ::
-    ( Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
-    env -> Lens.ALens' (Texts.CodeUI Text) Text -> E.Doc
+doc :: _ => env -> Lens.ALens' (Texts.CodeUI Text) Text -> E.Doc
 doc env lens =
     E.toDoc env
     [ has . MomentuTexts.edit
@@ -64,16 +53,7 @@ doc env lens =
 addAltId :: Widget.Id -> Widget.Id
 addAltId = (`Widget.joinId` ["add alt"])
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env, SearchMenu.HasTexts env, Has (TextEdit.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Expr Sugar.Composite i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Composite i o -> GuiM env i o (Responsive o)
 make (Ann (Const pl) (Sugar.Composite alts punned caseTail addAlt)) =
     do
         env <- Lens.view id
@@ -105,15 +85,7 @@ make (Ann (Const pl) (Sugar.Composite alts punned caseTail addAlt)) =
             <*> grammar (label Texts.case_)
             <&> Responsive.fromWithTextPos
 
-makeAltRow ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Body Sugar.CompositeItem i o -> GuiM env i o (TaggedItem o)
+makeAltRow :: _ => ExprGui.Body Sugar.CompositeItem i o -> GuiM env i o (TaggedItem o)
 makeAltRow (Sugar.CompositeItem delete tag altExpr) =
     do
         env <- Lens.view id
@@ -134,16 +106,7 @@ makeAltRow (Sugar.CompositeItem delete tag altExpr) =
         altId = tag ^. Sugar.tagRefTag . Sugar.tagInstance & WidgetIds.fromEntityId
 
 makeAltsWidget ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Grid.Texts Text) env
-    ) =>
+    _ =>
     [ExprGui.Body Sugar.CompositeItem i o] ->
     [Sugar.PunnedVar Name o # Annotated (ExprGui.Payload i o)] ->
     Sugar.TagChoice Name i o Sugar.EntityId ->
@@ -173,15 +136,7 @@ makeAltsWidget alts punned addAlt altsId =
             altWidgtes -> taggedList ?? altWidgtes
 
 makeAddAltRow ::
-    ( Monad i, Monad o
-    , Has (Texts.Name Text) env
-    , Has (Texts.CodeUI Text) env
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
-    Sugar.TagChoice Name i o Sugar.EntityId -> Widget.Id ->
-    GuiM env i o (TaggedItem o)
+    _ => Sugar.TagChoice Name i o Sugar.EntityId -> Widget.Id -> GuiM env i o (TaggedItem o)
 makeAddAltRow addAlt myId =
     TagEdit.makeTagHoleEdit addAlt mkPickResult myId
     & Styled.withColor TextColors.caseTagColor
@@ -206,9 +161,7 @@ separationBar theme animId width =
     & M.scale (M.Vector2 width 10)
 
 makeOpenCase ::
-    (Monad i, Monad o, Grid.HasTexts env) =>
-    ExprGui.Expr Sugar.Term i o ->
-    M.AnimId -> Responsive o -> GuiM env i o (Responsive o)
+    _ => ExprGui.Expr Sugar.Term i o -> M.AnimId -> Responsive o -> GuiM env i o (Responsive o)
 makeOpenCase rest animId altsGui =
     do
         theme <- Lens.view has
@@ -222,25 +175,12 @@ makeOpenCase rest animId altsGui =
             (separationBar (theme ^. Theme.textColors) animId <&> (|---| vspace))
             altsGui restExpr & pure
 
-closedCaseEventMap ::
-    ( Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Monad o
-    ) =>
-    env -> Sugar.ClosedCompositeActions o ->
-    EventMap (o GuiState.Update)
+closedCaseEventMap :: _ => env -> Sugar.ClosedCompositeActions o -> EventMap (o GuiState.Update)
 closedCaseEventMap env (Sugar.ClosedCompositeActions open) =
     open <&> WidgetIds.fromEntityId
     & E.keysEventMapMovesCursor (env ^. has . Config.caseOpenKeys) (doc env Texts.open)
 
-caseDelEventMap ::
-    ( Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Monad o
-    ) =>
-    env -> o Sugar.EntityId -> EventMap (o GuiState.Update)
+caseDelEventMap :: _ => env -> o Sugar.EntityId -> EventMap (o GuiState.Update)
 caseDelEventMap env delete =
     delete <&> WidgetIds.fromEntityId
     & E.keysEventMapMovesCursor (Config.delKeys env)

--- a/src/Lamdu/GUI/Expr/EventMap.hs
+++ b/src/Lamdu/GUI/Expr/EventMap.hs
@@ -14,11 +14,10 @@ import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
 import qualified GUI.Momentu.I18N as MomentuTexts
 import qualified GUI.Momentu.State as GuiState
-import           GUI.Momentu.Widget (HasWidget(..), EventContext)
+import           GUI.Momentu.Widget (EventContext)
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified Lamdu.CharClassification as Chars
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import           Lamdu.GUI.Expr.HoleEdit.ValTerms (allowedSearchTerm)
 import qualified Lamdu.GUI.Expr.HoleEdit.WidgetIds as HoleWidgetIds
@@ -75,22 +74,12 @@ exprInfoFromPl =
     }
 
 add ::
-    ( HasWidget w, Monad i, Monad o
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
+    _ =>
     Options -> (Sugar.Payload v name i o, ExprGui.GuiPayload) ->
     GuiM env i o (w o -> w o)
 add options pl = exprInfoFromPl ?? pl >>= addWith options
 
-addWith ::
-    ( HasWidget w, Monad i, Monad o
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
-    Options -> ExprInfo name i o -> GuiM env i o (w o -> w o)
+addWith :: _ => Options -> ExprInfo name i o -> GuiM env i o (w o -> w o)
 addWith options exprInfo =
     actionsEventMap options exprInfo <&> Widget.weakerEventsWithContext
 
@@ -98,13 +87,7 @@ extractCursor :: Sugar.ExtractDestination -> Widget.Id
 extractCursor (Sugar.ExtractToLet letId) = WidgetIds.fromEntityId letId
 extractCursor (Sugar.ExtractToDef defId) = WidgetIds.fromEntityId defId
 
-extractEventMap ::
-    ( MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.Definitions Text) env
-    , Functor o
-    ) =>
-    m (Sugar.NodeActions name i o -> EventMap (o GuiState.Update))
+extractEventMap :: _ => m (Sugar.NodeActions name i o -> EventMap (o GuiState.Update))
 extractEventMap =
     Lens.view id
     <&>
@@ -136,11 +119,7 @@ addLetEventMap addLet =
             & pure
 
 actionsEventMap ::
-    ( Monad i, Monad o
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
+    _ =>
     Options -> ExprInfo name i o ->
     GuiM env i o (EventContext -> EventMap (o GuiState.Update))
 actionsEventMap options exprInfo =
@@ -174,9 +153,7 @@ actionsEventMap options exprInfo =
 -- | Create the hole search term for new apply operators,
 -- given the extra search term chars from another hole.
 transformSearchTerm ::
-    ( MonadReader env m
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     m (ExprInfo name i o -> EventContext -> EventMap Text)
 transformSearchTerm =
     Lens.view id <&>
@@ -211,10 +188,7 @@ transformSearchTerm =
     <&> (searchStrRemainder <>)
 
 transformEventMap ::
-    ( MonadReader env m, Applicative o
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
-    m (Options -> ExprInfo name i o -> EventContext -> EventMap (o GuiState.Update))
+    _ => m (Options -> ExprInfo name i o -> EventContext -> EventMap (o GuiState.Update))
 transformEventMap =
     transformSearchTerm <&>
     \transform options exprInfo eventCtx ->
@@ -233,12 +207,7 @@ transformEventMap =
     where
         widgetId = pure . WidgetIds.fromEntityId
 
-detachEventMap ::
-    ( MonadReader env m, Has Config env, Has Dir.Layout env
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Functor o
-    ) =>
-    m (ExprInfo name i o -> EventMap (o GuiState.Update))
+detachEventMap :: _ => m (ExprInfo name i o -> EventMap (o GuiState.Update))
 detachEventMap =
     Lens.view id
     <&>
@@ -260,12 +229,7 @@ detachEventMap =
                 Dir.RightToLeft -> ")]"
     _ -> mempty
 
-replaceEventMap ::
-    ( MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Functor f
-    ) =>
-    Sugar.Delete f -> m (EventMap (f GuiState.Update))
+replaceEventMap :: _ => Sugar.Delete f -> m (EventMap (f GuiState.Update))
 replaceEventMap x =
     Lens.view id
     <&>
@@ -284,9 +248,7 @@ goToLiteral :: Sugar.EntityId -> GuiState.Update
 goToLiteral = GuiState.updateCursor . WidgetIds.literalEditOf . WidgetIds.fromEntityId
 
 makeLiteralNumberEventMap ::
-    ( MonadReader env m, Monad o
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     String ->
     m ((Sugar.Literal Identity -> o Sugar.EntityId) -> EventMap (o GuiState.Update))
 makeLiteralNumberEventMap prefix =
@@ -298,10 +260,7 @@ makeLiteralNumberEventMap prefix =
     (fmap goToLiteral . makeLiteral . Sugar.LiteralNum . Identity . read . (prefix <>) . (: []))
 
 makeLiteralTextEventMap ::
-    ( MonadReader env m, Monad o
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
-    m ((Sugar.Literal Identity -> o Sugar.EntityId) -> EventMap (o GuiState.Update))
+    _ => m ((Sugar.Literal Identity -> o Sugar.EntityId) -> EventMap (o GuiState.Update))
 makeLiteralTextEventMap =
     Lens.view id <&> E.toDoc <&>
     \toDoc makeLiteral ->
@@ -309,12 +268,7 @@ makeLiteralTextEventMap =
     (toDoc [has . MomentuTexts.edit, has . Texts.literalText]) "\""
     (const (makeLiteral (Sugar.LiteralText (Identity "")) <&> goToLiteral))
 
-makeRecordEventMap ::
-    ( MonadReader env m, Monad o
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Has Dir.Layout env
-    ) =>
-    m (o Sugar.EntityId -> EventMap (o GuiState.Update))
+makeRecordEventMap :: _ => m (o Sugar.EntityId -> EventMap (o GuiState.Update))
 makeRecordEventMap =
     Lens.view id <&>
     \env makeRec ->
@@ -325,12 +279,7 @@ makeRecordEventMap =
         Dir.RightToLeft -> "}"
     ) (const (makeRec <&> WidgetIds.fromEntityId <&> GuiState.updateCursor))
 
-makeLiteralEventMap ::
-    ( MonadReader env m, Monad o
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Has Dir.Layout env
-    ) =>
-    m (Sugar.NodeActions name i o -> EventMap (o GuiState.Update))
+makeLiteralEventMap :: _ => m (Sugar.NodeActions name i o -> EventMap (o GuiState.Update))
 makeLiteralEventMap =
     (<>)
     <$> ( (<>) <$> makeLiteralTextEventMap <*> makeLiteralNumberEventMap ""

--- a/src/Lamdu/GUI/Expr/FragmentEdit.hs
+++ b/src/Lamdu/GUI/Expr/FragmentEdit.hs
@@ -8,7 +8,6 @@ import qualified GUI.Momentu.Animation as Anim
 import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Element as Element
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.Responsive (Responsive(..))
 import qualified GUI.Momentu.Responsive as Responsive
@@ -18,9 +17,7 @@ import qualified GUI.Momentu.View as View
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.Menu as Menu
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.Config as Config
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.ValAnnotation as ValAnnotation
@@ -33,36 +30,17 @@ import qualified Lamdu.GUI.Monad as GuiM
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrapParentExpr)
-import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-fragmentDoc ::
-    ( Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
-    env -> Lens.ALens' env Text -> E.Doc
+fragmentDoc :: _ => env -> Lens.ALens' env Text -> E.Doc
 fragmentDoc env lens =
     E.toDoc env
     [has . MomentuTexts.edit, has . Texts.fragment, lens]
 
-make ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , Has (TextEdit.Texts Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Navigation Text) env
-    , SearchMenu.HasTexts env
-    ) =>
-    ExprGui.Expr Sugar.Fragment i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Fragment i o -> GuiM env i o (Responsive o)
 make (Ann (Const pl) fragment) =
     do
         isSelected <- GuiState.isSubCursor ?? myId

--- a/src/Lamdu/GUI/Expr/GetFieldEdit.hs
+++ b/src/Lamdu/GUI/Expr/GetFieldEdit.hs
@@ -5,36 +5,18 @@ module Lamdu.GUI.Expr.GetFieldEdit
 import           GUI.Momentu ((/|/))
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.GUI.Expr.TagEdit as TagEdit
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.Types as ExprGui
 import           Lamdu.GUI.Wrap (stdWrapParentExpr)
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Payload i o -> Sugar.TagRef Name i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Payload i o -> Sugar.TagRef Name i o -> GuiM env i o (Responsive o)
 make pl tag =
     Styled.grammar (Label.make ".") /|/ TagEdit.makeRecordTag tag
     <&> Responsive.fromWithTextPos

--- a/src/Lamdu/GUI/Expr/GetVarEdit.hs
+++ b/src/Lamdu/GUI/Expr/GetVarEdit.hs
@@ -9,11 +9,9 @@ import qualified Control.Monad.Reader as Reader
 import qualified Data.ByteString.Char8 as SBS8
 import qualified GUI.Momentu as M
 import qualified GUI.Momentu.Align as Align
-import qualified GUI.Momentu.Direction as Dir
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
 import           GUI.Momentu.Font (Underline(..))
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.Hover as Hover
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.MetaKey (MetaKey(..), noMods)
@@ -27,9 +25,7 @@ import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.Config.Theme.TextColors (TextColors)
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -46,7 +42,6 @@ import           Lamdu.GUI.Wrap (stdWrap)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
 import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Name as Name
@@ -54,25 +49,13 @@ import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-makeSimpleView ::
-    ( MonadReader env m, GuiState.HasCursor env, Has Theme env
-    , Applicative f, M.HasAnimIdPrefix env, Has TextView.Style env
-    , Has Dir.Layout env, Has (Texts.Name Text) env
-    ) =>
-    Lens.ALens' TextColors M.Color -> Name -> Widget.Id ->
-    m (M.TextWidget f)
+makeSimpleView :: _ => Lens.ALens' TextColors M.Color -> Name -> Widget.Id -> m (M.TextWidget f)
 makeSimpleView color name myId =
     (Widget.makeFocusableView ?? myId <&> (Align.tValue %~))
     <*> NameView.make name
     & Styled.withColor (Lens.cloneLens color)
 
-makeParamsRecord ::
-    ( MonadReader env m, Has Theme env, GuiState.HasCursor env
-    , M.HasAnimIdPrefix env, Spacer.HasStdSpacing env
-    , Glue.HasTexts env, Has (Texts.Code Text) env, Has (Texts.Name Text) env
-    , Applicative f
-    ) =>
-    Widget.Id -> Sugar.ParamsRecordVarRef Name -> m (Responsive f)
+makeParamsRecord :: _ => Widget.Id -> Sugar.ParamsRecordVarRef Name -> m (Responsive f)
 makeParamsRecord myId paramsRecordVar =
     do
         respondToCursor <- Widget.respondToCursorPrefix ?? myId
@@ -99,20 +82,12 @@ makeParamsRecord myId paramsRecordVar =
 
 data Role = Normal | Operator deriving Eq
 
-navDoc ::
-    ( Has (Texts.Navigation Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
-    env -> Lens.ALens' (Texts.Navigation Text) Text -> E.Doc
+navDoc :: _ => env -> Lens.ALens' (Texts.Navigation Text) Text -> E.Doc
 navDoc env lens =
     E.toDoc env [has . MomentuTexts.navigation, has . lens]
 
 makeNameRef ::
-    ( Monad i, Monad o
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.Name Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
+    _ =>
     Role ->
     Lens.ALens' TextColors M.Color -> Widget.Id ->
     Sugar.NameRef Name o ->
@@ -146,14 +121,7 @@ makeNameRef role color myId nameRef =
         name = nameRef ^. Sugar.nrName
         nameId = Widget.joinId myId ["name"]
 
-makeInlineEventMap ::
-    ( Has Config env, Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Navigation Text) env
-    , Applicative f
-    ) =>
-    env -> Sugar.BinderVarInline f ->
-    EventMap (f GuiState.Update)
+makeInlineEventMap :: _ => env -> Sugar.BinderVarInline f -> EventMap (f GuiState.Update)
 makeInlineEventMap env (Sugar.InlineVar inline) =
     inline <&> WidgetIds.fromEntityId
     & E.keysEventMapMovesCursor (env ^. has . Config.inlineKeys)
@@ -165,15 +133,7 @@ makeInlineEventMap env (Sugar.CannotInlineDueToUses (x:_)) =
 makeInlineEventMap _ _ = mempty
 
 definitionTypeChangeBox ::
-    ( MonadReader env m, Glue.HasTexts env, Has (Texts.Code Text) env
-    , M.HasAnimIdPrefix env, Has (Texts.Definitions Text) env
-    , Spacer.HasStdSpacing env, Has Theme env, GuiState.HasCursor env
-    , Has Config env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    , Applicative f
-    ) =>
-    Sugar.DefinitionOutdatedType Name f Sugar.EntityId -> Widget.Id ->
-    m (M.TextWidget f)
+    _ => Sugar.DefinitionOutdatedType Name f Sugar.EntityId -> Widget.Id -> m (M.TextWidget f)
 definitionTypeChangeBox info getVarId =
     do
         env <- Lens.view id
@@ -205,17 +165,7 @@ definitionTypeChangeBox info getVarId =
         animId = Widget.toAnimId myId
 
 processDefinitionWidget ::
-    ( MonadReader env m, Spacer.HasStdSpacing env
-    , Has Theme env, M.HasAnimIdPrefix env, Has Config env
-    , GuiState.HasCursor env, Has Hover.Style env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    , Applicative f
-    ) =>
-    Sugar.DefinitionForm Name f -> Widget.Id ->
-    m (M.TextWidget f) ->
-    m (M.TextWidget f)
+    _ => Sugar.DefinitionForm Name f -> Widget.Id -> m (M.TextWidget f) -> m (M.TextWidget f)
 processDefinitionWidget Sugar.DefUpToDate _myId mkLayout = mkLayout
 processDefinitionWidget Sugar.DefDeleted _myId mkLayout =
     Styled.deletedUse <*> mkLayout
@@ -262,16 +212,7 @@ processDefinitionWidget (Sugar.DefTypeChanged info) myId mkLayout =
         hiddenId = myId `Widget.joinId` ["hidden"]
 
 makeGetBinder ::
-    ( Monad i, Monad o
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Grid.HasTexts env
-    ) =>
-    Role -> Sugar.BinderVarRef Name o -> Widget.Id ->
-    GuiM env i o (M.TextWidget o)
+    _ => Role -> Sugar.BinderVarRef Name o -> Widget.Id -> GuiM env i o (M.TextWidget o)
 makeGetBinder role binderVar myId =
     do
         env <- Lens.view id
@@ -287,14 +228,7 @@ makeGetBinder role binderVar myId =
                 (makeInlineEventMap env (binderVar ^. Sugar.bvInline))
             & processDef
 
-makeGetParam ::
-    ( Monad i, Monad o
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.Name Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
-    Sugar.ParamRef Name o -> Widget.Id ->
-    GuiM env i o (M.TextWidget o)
+makeGetParam :: _ => Sugar.ParamRef Name o -> Widget.Id -> GuiM env i o (M.TextWidget o)
 makeGetParam param myId =
     do
         underline <- Lens.view has <&> LightLambda.underline
@@ -309,11 +243,7 @@ makeGetParam param myId =
         name = param ^. Sugar.pNameRef . Sugar.nrName
 
 make ::
-    ( Monad i, Monad o
-    , Has (Texts.Definitions Text) env, Has (Texts.Navigation Text) env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    ) =>
+    _ =>
     Annotated (ExprGui.Payload i o) # Const (Sugar.GetVar Name o) ->
     GuiM env i o (Responsive o)
 make (Ann (Const pl) (Const getVar)) =
@@ -329,11 +259,7 @@ make (Ann (Const pl) (Const getVar)) =
         myId = pl ^. _1 & WidgetIds.fromExprPayload
 
 makePunnedVar ::
-    ( Monad i, Monad o
-    , Has (Texts.Definitions Text) env, Has (Texts.Navigation Text) env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    ) =>
+    _ =>
     Sugar.PunnedVar Name o # Annotated (ExprGui.Payload i o) ->
     GuiM env i o (Responsive o)
 makePunnedVar (Sugar.PunnedVar var tagId) =
@@ -343,11 +269,7 @@ makePunnedVar (Sugar.PunnedVar var tagId) =
         (WidgetIds.fromExprPayload (var ^. annotation . _1))
 
 makePunnedVars ::
-    ( Monad i, Monad o
-    , Has (Texts.Definitions Text) env, Has (Texts.Navigation Text) env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env, Grid.HasTexts env
-    ) =>
+    _ =>
     [Sugar.PunnedVar Name o # Annotated (ExprGui.Payload i o)] ->
     GuiM env i o (Responsive o)
 makePunnedVars args =

--- a/src/Lamdu/GUI/Expr/HoleEdit.hs
+++ b/src/Lamdu/GUI/Expr/HoleEdit.hs
@@ -6,13 +6,11 @@ import qualified Control.Lens as Lens
 import qualified Data.Char as Char
 import qualified Data.Text as Text
 import qualified GUI.Momentu.Align as Align
-import qualified GUI.Momentu.Glue as Glue
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.GUI.Expr.EventMap as ExprEventMap
 import qualified Lamdu.GUI.Expr.HoleEdit.SearchArea as SearchArea
 import           Lamdu.GUI.Expr.HoleEdit.ValTerms (allowedSearchTerm)
@@ -20,10 +18,6 @@ import           Lamdu.GUI.Expr.HoleEdit.WidgetIds (WidgetIds(..))
 import qualified Lamdu.GUI.Expr.HoleEdit.WidgetIds as HoleWidgetIds
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Types as ExprGui
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
@@ -42,18 +36,7 @@ allowedHoleSearchTerm searchTerm =
             Just (c, rest) -> c == char && restPred rest
             _ -> False
 
-make ::
-    ( Monad i, Monad o
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
-    Annotated (ExprGui.Payload i o) # Const (Sugar.Hole Name i o) ->
-    GuiM env i o (Responsive o)
+make :: _ => Annotated (ExprGui.Payload i o) # Const (Sugar.Hole Name i o) -> GuiM env i o (Responsive o)
 make (Ann (Const pl) (Const hole)) =
     do
         searchTerm <- SearchMenu.readSearchTerm searchMenuId

--- a/src/Lamdu/GUI/Expr/HoleEdit/ResultGroups.hs
+++ b/src/Lamdu/GUI/Expr/HoleEdit/ResultGroups.hs
@@ -23,8 +23,6 @@ import qualified Lamdu.GUI.Expr.HoleEdit.ValTerms as ValTerms
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Monad as GuiM
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
@@ -151,10 +149,7 @@ isGoodResult :: Sugar.HoleResultScore -> Bool
 isGoodResult hrs = hrs ^. Sugar.hrsNumFragments == 0
 
 makeAll ::
-    ( Monad i
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     [Sugar.HoleOption Name i o1] ->
     SearchMenu.ResultsContext ->
     GuiM env i o (Menu.OptionList (ResultGroup i o1))
@@ -172,12 +167,7 @@ makeAll options ctx =
     where
         searchTerm = ctx ^. SearchMenu.rSearchTerm
 
-mkGroup ::
-    ( Monad i
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
-    env -> Sugar.HoleOption Name i o -> i (Group i o)
+mkGroup :: _ => env -> Sugar.HoleOption Name i o -> i (Group i o)
 mkGroup env option =
     option ^. Sugar.hoSearchTerms
     <&>

--- a/src/Lamdu/GUI/Expr/HoleEdit/ResultWidget.hs
+++ b/src/Lamdu/GUI/Expr/HoleEdit/ResultWidget.hs
@@ -20,7 +20,6 @@ import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
 import           Hyper (htraverse, (#>), withDict)
-import           Lamdu.Config (Config(..))
 import qualified Lamdu.Config as Config
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.GUI.Monad (GuiM)
@@ -38,8 +37,7 @@ setFocalAreaToFullSize =
     (:[]) . Rect 0
 
 -- | Remove unwanted event handlers from a hole result
-removeUnwanted ::
-    (MonadReader env m, Has Config env) => m (EventMap a -> EventMap a)
+removeUnwanted :: _ => m (EventMap a -> EventMap a)
 removeUnwanted =
     Lens.view has
     <&>
@@ -76,7 +74,7 @@ makeWidget resultId holeResultConverted =
             & GuiM.withLocalIsHoleResult
 
 make ::
-    (Monad i, Monad o, Has (MomentuTexts.Texts Text) env) =>
+    _ =>
     Widget.Id -> o () -> ExprGui.Expr Sugar.Binder i o ->
     GuiM env i o (Menu.RenderedOption o)
 make resultId pick holeResultConverted =

--- a/src/Lamdu/GUI/Expr/HoleEdit/SearchArea.hs
+++ b/src/Lamdu/GUI/Expr/HoleEdit/SearchArea.hs
@@ -16,7 +16,6 @@ import qualified GUI.Momentu as M
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
@@ -24,12 +23,9 @@ import qualified GUI.Momentu.Widgets.FocusDelegator as FocusDelegator
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
-import           Hyper
+import           Hyper (HFunctor(..), hflipped)
 import qualified Lamdu.CharClassification as Chars
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.GUI.Expr.HoleEdit.ResultGroups (ResultGroup(..), Result(..))
 import qualified Lamdu.GUI.Expr.HoleEdit.ResultGroups as ResultGroups
@@ -42,9 +38,7 @@ import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Monad as GuiM
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.TypeView as TypeView
-import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Lens as SugarLens
 import qualified Lamdu.Sugar.Parens as AddParens
@@ -52,11 +46,7 @@ import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-fdConfig ::
-    ( Has Config env
-    , Has (Texts.CodeUI Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) => env -> FocusDelegator.Config
+fdConfig :: _ => env -> FocusDelegator.Config
 fdConfig env = FocusDelegator.Config
     { FocusDelegator.focusChildKeys =
         env ^. has . Config.completion . Config.completionOpenKeys
@@ -76,8 +66,7 @@ fdConfig env = FocusDelegator.Config
     }
 
 makeRenderedResult ::
-    (Monad i, Monad o, Has (MomentuTexts.Texts Text) env) =>
-    ExprGui.GuiPayload -> Result i o -> GuiM env i o (Menu.RenderedOption o)
+    _ => ExprGui.GuiPayload -> Result i o -> GuiM env i o (Menu.RenderedOption o)
 makeRenderedResult pl result =
     do
         -- Warning: rHoleResult should be ran at most once!
@@ -105,8 +94,7 @@ postProcessSugar minOpPrec binder =
             <$ sugarPl
 
 makeResultOption ::
-    (Monad i, Monad o, Has (MomentuTexts.Texts Text) env) =>
-    ExprGui.GuiPayload -> ResultGroup i o -> Menu.Option (GuiM env i o) o
+    _ => ExprGui.GuiPayload -> ResultGroup i o -> Menu.Option (GuiM env i o) o
 makeResultOption pl results =
     Menu.Option
     { Menu._oId = results ^. ResultGroups.rgPrefixId
@@ -128,11 +116,7 @@ makeResultOption pl results =
             }
 
 makeInferredTypeAnnotation ::
-    ( MonadReader env m, Has Theme env, M.HasAnimIdPrefix env
-    , Spacer.HasStdSpacing env, Has (Texts.Name Text) env, Glue.HasTexts env
-    , Has (Texts.Code Text) env
-    ) =>
-    Sugar.Annotation v Name -> M.AnimId -> m M.View
+    _ => Sugar.Annotation v Name -> M.AnimId -> m M.View
 makeInferredTypeAnnotation ann animId =
     Annotation.addAnnotationBackground
     <*> TypeView.make (ann ^?! Sugar._AnnotationType)
@@ -157,14 +141,7 @@ searchTermFilter t =
     _ -> Sugar.OptsNormal
 
 make ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (TextEdit.Texts Text) env
-    , SearchMenu.HasTexts env
-    ) =>
+    _ =>
     AnnotationMode ->
     i (Sugar.OptionFilter -> [Sugar.HoleOption Name i o]) ->
     ExprGui.Payload i o -> (Text -> Bool) -> WidgetIds ->

--- a/src/Lamdu/GUI/Expr/InjectEdit.hs
+++ b/src/Lamdu/GUI/Expr/InjectEdit.hs
@@ -6,37 +6,18 @@ import           GUI.Momentu ((/|/))
 import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Responsive.Expression as ResponsiveExpr
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified Lamdu.GUI.Expr.TagEdit as TagEdit
 import           Lamdu.GUI.Monad (GuiM)
 import           Lamdu.GUI.Styled (text, grammar)
 import           Lamdu.GUI.Wrap (stdWrap)
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Annotated (ExprGui.Payload i o) # Const (Sugar.TagRef Name i o) ->
-    GuiM env i o (Responsive o)
+make :: _ => Annotated (ExprGui.Payload i o) # Const (Sugar.TagRef Name i o) -> GuiM env i o (Responsive o)
 make (Ann (Const pl) (Const tag)) =
     maybe (pure id) (ResponsiveExpr.addParens ??) (ExprGui.mParensId pl)
     <*> grammar (text ["injectIndicator"] Texts.injectSymbol) /|/ TagEdit.makeVariantTag tag

--- a/src/Lamdu/GUI/Expr/LambdaEdit.hs
+++ b/src/Lamdu/GUI/Expr/LambdaEdit.hs
@@ -16,13 +16,8 @@ import qualified GUI.Momentu.Responsive.Expression as ResponsiveExpr
 import qualified GUI.Momentu.Responsive.Options as Options
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.GUI.Expr.AssignmentEdit as AssignmentEdit
 import qualified Lamdu.GUI.LightLambda as LightLambda
 import           Lamdu.GUI.Monad (GuiM)
@@ -32,35 +27,22 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrapParentExpr)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-addScopeEdit ::
-    (MonadReader env m, Applicative o, Glue.HasTexts env) =>
-    m (Maybe (M.Widget o) -> Responsive o -> Responsive o)
+addScopeEdit :: _ => m (Maybe (M.Widget o) -> Responsive o -> Responsive o)
 addScopeEdit =
     Glue.mkGlue ?? Glue.Vertical
     <&> (\(|---|) mScopeEdit ->
                 (|---| maybe M.empty (M.WithTextPos 0) mScopeEdit))
 
-mkLhsEdits ::
-    (MonadReader env m, Applicative o, Glue.HasTexts env) =>
-    m
-    (Maybe (Responsive o) ->
-     Maybe (M.Widget o) -> [Responsive o])
+mkLhsEdits :: _ => m (Maybe (Responsive o) -> Maybe (M.Widget o) -> [Responsive o])
 mkLhsEdits =
     addScopeEdit <&> \add mParamsEdit mScopeEdit ->
     mParamsEdit ^.. Lens._Just <&> add mScopeEdit
 
-mkExpanded ::
-    ( Monad o, MonadReader env f, Has Theme env, Has TextView.Style env
-    , M.HasAnimIdPrefix env, Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
-    f (Maybe (Responsive o) -> Maybe (M.Widget o) -> [Responsive o])
+mkExpanded :: _ => f (Maybe (Responsive o) -> Maybe (M.Widget o) -> [Responsive o])
 mkExpanded =
     (,)
     <$> mkLhsEdits
@@ -71,14 +53,7 @@ mkExpanded =
 lamId :: Widget.Id -> Widget.Id
 lamId = (`Widget.joinId` ["lam"])
 
-mkShrunk ::
-    ( Monad o, MonadReader env f, Has Config env, Has Theme env
-    , GuiState.HasCursor env, M.HasAnimIdPrefix env, Has TextView.Style env
-    , Glue.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    ) => [Sugar.EntityId] -> Widget.Id ->
-    f (Maybe (M.Widget o) -> [Responsive o])
+mkShrunk :: _ => [Sugar.EntityId] -> Widget.Id -> f (Maybe (M.Widget o) -> [Responsive o])
 mkShrunk paramIds myId =
     do
         env <- Lens.view id
@@ -105,17 +80,9 @@ mkShrunk paramIds myId =
             ]
 
 mkLightLambda ::
-    ( Monad o, MonadReader env f, GuiState.HasCursor env
-    , M.HasAnimIdPrefix env, Has TextView.Style env, Has Theme env
-    , Has Config env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Glue.HasTexts env
-    ) =>
+    _ =>
     Sugar.BinderParams v a i o -> Widget.Id ->
-    f
-    (Maybe (Responsive o) -> Maybe (M.Widget o) ->
-     [Responsive o])
+    f (Maybe (Responsive o) -> Maybe (M.Widget o) -> [Responsive o])
 mkLightLambda params myId =
     do
         isSelected <-
@@ -143,18 +110,7 @@ mkLightLambda params myId =
             Sugar.NullParam{} -> []
             Sugar.Params ps -> ps <&> (^. _2 . Sugar.piTag . Sugar.tagRefTag . Sugar.tagInstance)
 
-make ::
-    ( Monad i, Monad o
-    , Grid.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Expr Sugar.Lambda i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Lambda i o -> GuiM env i o (Responsive o)
 make (Ann (Const pl) lam) =
     do
         AssignmentEdit.Parts mParamsEdit mScopeEdit bodyEdit eventMap _wrap rhsId <-

--- a/src/Lamdu/GUI/Expr/LiteralEdit.hs
+++ b/src/Lamdu/GUI/Expr/LiteralEdit.hs
@@ -10,11 +10,9 @@ import           Data.Property (Property)
 import qualified Data.Property as Property
 import qualified Data.Text as Text
 import qualified GUI.Momentu as M
-import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import qualified GUI.Momentu.MetaKey as MetaKey
 import           GUI.Momentu.ModKey (ModKey(..))
@@ -23,13 +21,11 @@ import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.FocusDelegator as FocusDelegator
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextEdit.Property as TextEdits
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import           Lamdu.Formatting (Format(..))
 import           Lamdu.GUI.Expr.EventMap (makeLiteralEventMap)
@@ -41,21 +37,14 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrap)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
-import           Lamdu.Style (Style, HasStyle)
+import           Lamdu.Style (Style)
 import qualified Lamdu.Style as Style
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-mkEditEventMap ::
-    ( MonadReader env m
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Monad o
-    ) =>
-    m (Text -> o Sugar.EntityId -> EventMap (o M.Update))
+mkEditEventMap :: _ => m (Text -> o Sugar.EntityId -> EventMap (o M.Update))
 mkEditEventMap =
     Lens.view id
     <&> \env valText setToHole ->
@@ -64,17 +53,12 @@ mkEditEventMap =
     & E.keyPresses [ModKey mempty MetaKey.Key'Enter]
     (E.toDoc env [has . MomentuTexts.edit, has . Texts.value])
 
-withStyle ::
-    (MonadReader env m, HasStyle env) =>
-    Lens.Getting TextEdit.Style Style TextEdit.Style -> m a -> m a
+withStyle :: _ => Lens.Getting TextEdit.Style Style TextEdit.Style -> m a -> m a
 withStyle whichStyle =
     Reader.local (\x -> x & has .~ x ^. has . whichStyle)
 
 genericEdit ::
-    ( Monad o, Format a, MonadReader env f, HasStyle env, M.HasCursor env
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    , Has Dir.Layout env
-    ) =>
+    _ =>
     LensLike' (Const TextEdit.Style) Style TextEdit.Style ->
     Property o a ->
     Sugar.Payload v name i o -> f (Responsive o)
@@ -92,11 +76,7 @@ genericEdit whichStyle prop pl =
         myId = WidgetIds.fromExprPayload pl
         valText = prop ^. Property.pVal & format
 
-fdConfig ::
-    ( MonadReader env m, Has Config env, Has Menu.Config env
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
-    m FocusDelegator.Config
+fdConfig :: _ => m FocusDelegator.Config
 fdConfig =
     Lens.view id
     <&> \env ->
@@ -127,26 +107,12 @@ fdConfig =
         ]
     }
 
-withFd ::
-    ( MonadReader env m, Has Config env, M.HasCursor env
-    , Has Menu.Config env, Applicative f
-    , Has (MomentuTexts.Texts Text) env, Has (Texts.CodeUI Text) env
-    ) =>
-    m (Widget.Id -> M.TextWidget f -> M.TextWidget f)
+withFd :: _ => m (Widget.Id -> M.TextWidget f -> M.TextWidget f)
 withFd =
     FocusDelegator.make <*> fdConfig ?? FocusDelegator.FocusEntryParent
     <&> Lens.mapped %~ (M.tValue %~)
 
-textEdit ::
-    ( MonadReader env m, Has Config env, HasStyle env, Has Menu.Config env
-    , M.HasAnimIdPrefix env, M.HasCursor env
-    , Glue.HasTexts env, TextEdit.HasTexts env
-    , Has (Texts.Code Text) env, Has (Texts.CodeUI Text) env
-    , Monad o
-    ) =>
-    Property o Text ->
-    Sugar.Payload v name i o ->
-    m (M.TextWidget o)
+textEdit :: _ => Property o Text -> Sugar.Payload v name i o -> m (M.TextWidget o)
 textEdit prop pl =
     do
         text <- TextEdits.make ?? empty ?? prop ?? WidgetIds.literalEditOf myId
@@ -168,17 +134,7 @@ parseNum newText
     | newText `elem` ["", "-", ".", "-."] = Just 0
     | otherwise = tryParse newText
 
-numEdit ::
-    ( MonadReader env m, Monad o
-    , Has Config env, HasStyle env, Has Menu.Config env
-    , Has (Texts.CodeUI Text) env, Has (MomentuTexts.Texts Text) env
-    , Has (Dir.Texts Text) env, Has (Texts.Navigation Text) env
-    , Has (TextEdit.Texts Text) env, Has Dir.Layout env
-    , GuiState.HasState env
-    ) =>
-    Property o Double ->
-    Sugar.Payload v name i o ->
-    m (M.TextWidget o)
+numEdit :: _ => Property o Double -> Sugar.Payload v name i o -> m (M.TextWidget o)
 numEdit prop pl =
     (withFd ?? myId) <*>
     do
@@ -269,15 +225,7 @@ numEdit prop pl =
         myId = WidgetIds.fromExprPayload pl
 
 make ::
-    ( Monad i, Monad o
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Navigation Text) env
-    , TextEdit.HasTexts env
-    , Grid.HasTexts env
-    ) =>
+    _ =>
     Annotated (ExprGui.Payload i o) # Const (Sugar.Literal (Property o)) ->
     GuiM env i o (Responsive o)
 make (Ann (Const pl) (Const lit)) =

--- a/src/Lamdu/GUI/Expr/NominalEdit.hs
+++ b/src/Lamdu/GUI/Expr/NominalEdit.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+
 module Lamdu.GUI.Expr.NominalEdit
     ( makeFromNom, makeToNom
     ) where
@@ -12,7 +13,6 @@ import           GUI.Momentu.Responsive (Responsive)
 import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.Responsive.Expression as ResponsiveExpr
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.TextView as TextView
 import qualified Lamdu.Config as Config
@@ -25,25 +25,13 @@ import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrapParentExpr)
-import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
-import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-makeToNom ::
-    ( Monad i, Monad o, Grid.HasTexts env
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Definitions Text) env
-    ) =>
-    ExprGui.Expr Sugar.Nominal i o -> GuiM env i o (Responsive o)
+makeToNom :: _ => ExprGui.Expr Sugar.Nominal i o -> GuiM env i o (Responsive o)
 makeToNom (Ann (Const pl) (Sugar.Nominal tid binder)) =
     do
         env <- Lens.view id
@@ -73,25 +61,14 @@ makeToNom (Ann (Const pl) (Sugar.Nominal tid binder)) =
         nameId = Widget.joinId myId ["name"]
 
 makeFromNom ::
-    ( Monad i, Monad o, Grid.HasTexts env
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Definitions Text) env
-    ) =>
-    Annotated (ExprGui.Payload i o) # Const (Sugar.TId Name) ->
-    GuiM env i o (Responsive o)
+    _ => Annotated (ExprGui.Payload i o) # Const (Sugar.TId Name) -> GuiM env i o (Responsive o)
 makeFromNom (Ann (Const pl) (Const nom)) =
     Styled.grammar (Label.make ".")
     M./|/ mkNomLabel nom
     <&> Responsive.fromTextView
     & stdWrapParentExpr pl
 
-mkNomLabel ::
-    (Monad i, Has (Texts.Name Text) env) =>
-    Sugar.TId Name ->
-    GuiM env i o (M.WithTextPos M.View)
+mkNomLabel :: _ => Sugar.TId Name -> GuiM env i o (M.WithTextPos M.View)
 mkNomLabel tid =
     do
         nomColor <- Lens.view (has . Theme.textColors . TextColors.nomColor)

--- a/src/Lamdu/GUI/Expr/RecordEdit.hs
+++ b/src/Lamdu/GUI/Expr/RecordEdit.hs
@@ -6,7 +6,6 @@ import qualified Control.Lens as Lens
 import qualified Data.Char as Char
 import qualified Data.Text as Text
 import qualified GUI.Momentu as M
-import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
@@ -18,15 +17,10 @@ import           GUI.Momentu.Responsive.TaggedList (TaggedItem(..), taggedList, 
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.View as View
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
-import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.Config.Theme.TextColors (TextColors)
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -41,32 +35,19 @@ import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.GUI.Wrap (stdWrap, stdWrapParentExpr)
 import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-doc ::
-    ( Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
-    env -> Lens.ALens' (Texts.CodeUI Text) Text -> E.Doc
+doc :: _ => env -> Lens.ALens' (Texts.CodeUI Text) Text -> E.Doc
 doc env lens = E.toDoc env [has . MomentuTexts.edit, has . Texts.record, has . lens]
 
 addFieldId :: Widget.Id -> Widget.Id
 addFieldId = (`Widget.joinId` ["add field"])
 
-mkAddFieldEventMap ::
-    ( MonadReader env m
-    , Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Applicative o
-    ) =>
-    Widget.Id -> m (EventMap (o GuiState.Update))
+mkAddFieldEventMap :: _ => Widget.Id -> m (EventMap (o GuiState.Update))
 mkAddFieldEventMap myId =
     Lens.view id
     <&>
@@ -76,11 +57,7 @@ mkAddFieldEventMap myId =
     & E.keysEventMapMovesCursor (env ^. has . Config.recordAddFieldKeys)
     (doc env Texts.addField)
 
-addFieldWithSearchTermEventMap ::
-    ( Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Applicative o
-    ) => env -> Widget.Id -> EventMap (o GuiState.Update)
+addFieldWithSearchTermEventMap :: _ => env -> Widget.Id -> EventMap (o GuiState.Update)
 addFieldWithSearchTermEventMap env myId =
     E.charEventMap "Letter" (doc env Texts.addField) f
     where
@@ -92,15 +69,7 @@ addFieldWithSearchTermEventMap env myId =
                 & Just
             | otherwise = Nothing
 
-makeUnit ::
-    ( Monad i, Monad o
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Grid.HasTexts env
-    ) =>
-    ExprGui.Payload i o -> GuiM env i o (Responsive o)
+makeUnit :: _ => ExprGui.Payload i o -> GuiM env i o (Responsive o)
 makeUnit pl =
     do
         makeFocusable <- Widget.makeFocusableView ?? myId <&> (M.tValue %~)
@@ -116,18 +85,7 @@ makeUnit pl =
     where
         myId = WidgetIds.fromExprPayload (pl ^. _1)
 
-make ::
-    ( Monad i, Monad o
-    , SearchMenu.HasTexts env
-    , Grid.HasTexts env
-    , Has (TextEdit.Texts Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Expr Sugar.Composite i o -> GuiM env i o (Responsive o)
+make :: _ => ExprGui.Expr Sugar.Composite i o -> GuiM env i o (Responsive o)
 make (Ann (Const pl) (Sugar.Composite [] [] Sugar.ClosedComposite{} addField)) =
     -- Ignore the ClosedComposite actions - it only has the open
     -- action which is equivalent ot deletion on the unit record
@@ -175,14 +133,7 @@ make (Ann (Const pl) (Sugar.Composite fields punned recordTail addField)) =
             Sugar.OpenComposite restExpr -> makeOpenRecord restExpr
             _ -> pure
 
-makeRecord ::
-    ( MonadReader env m, Has Theme env, M.HasAnimIdPrefix env
-    , Spacer.HasStdSpacing env, Applicative o
-    , Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
-    (Responsive o -> m (Responsive o)) ->
-    [TaggedItem o] ->
-    m (Responsive o)
+makeRecord :: _ => (Responsive o -> m (Responsive o)) -> [TaggedItem o] -> m (Responsive o)
 makeRecord _ [] = error "makeRecord with no fields"
 makeRecord postProcess fieldGuis =
     Styled.addValFrame <*>
@@ -192,11 +143,7 @@ makeRecord postProcess fieldGuis =
                 >>= postProcess)
     )
 
-addPostTags ::
-    ( MonadReader env m, Has Theme env, Has TextView.Style env
-    , M.HasAnimIdPrefix env, Has (Texts.Code Text) env, Has Dir.Layout env
-    ) =>
-    [TaggedItem o] -> m [TaggedItem o]
+addPostTags :: _ => [TaggedItem o] -> m [TaggedItem o]
 addPostTags items =
     do
         let f idx item =
@@ -212,12 +159,7 @@ addPostTags items =
         lastIdx = length items - 1
 
 makeAddFieldRow ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    ) =>
+    _ =>
     Sugar.TagChoice Name i o Sugar.EntityId ->
     Sugar.Payload v name i o ->
     GuiM env i o (TaggedItem o)
@@ -239,15 +181,7 @@ makeAddFieldRow addField pl =
             , Menu._pickMNextEntry = WidgetIds.fromEntityId dst & Just
             }
 
-makeFieldRow ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Body Sugar.CompositeItem i o -> GuiM env i o (TaggedItem o)
+makeFieldRow :: _ => ExprGui.Body Sugar.CompositeItem i o -> GuiM env i o (TaggedItem o)
 makeFieldRow (Sugar.CompositeItem delete tag fieldExpr) =
     do
         itemEventMap <- recordDelEventMap delete
@@ -268,10 +202,7 @@ separationBar theme animId width =
     & M.tint (theme ^. TextColors.recordTailColor)
     & M.scale (M.Vector2 width 10)
 
-makeOpenRecord ::
-    (Monad i, Monad o, Glue.HasTexts env) =>
-    ExprGui.Expr Sugar.Term i o -> Responsive o ->
-    GuiM env i o (Responsive o)
+makeOpenRecord :: _ => ExprGui.Expr Sugar.Term i o -> Responsive o -> GuiM env i o (Responsive o)
 makeOpenRecord rest fieldsGui =
     do
         theme <- Lens.view has
@@ -284,13 +215,7 @@ makeOpenRecord rest fieldsGui =
             ?? (separationBar (theme ^. Theme.textColors) animId <&> (|---| vspace))
             ?? fieldsGui ?? restExpr
 
-closedRecordEventMap ::
-    ( MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Functor o
-    ) =>
-    Sugar.ClosedCompositeActions o -> m (EventMap (o GuiState.Update))
+closedRecordEventMap :: _ => Sugar.ClosedCompositeActions o -> m (EventMap (o GuiState.Update))
 closedRecordEventMap (Sugar.ClosedCompositeActions open) =
     Lens.view id
     <&>
@@ -299,13 +224,7 @@ closedRecordEventMap (Sugar.ClosedCompositeActions open) =
     & E.keysEventMapMovesCursor (env ^. has . Config.recordOpenKeys)
     (doc env Texts.open)
 
-recordDelEventMap ::
-    ( MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Functor o
-    ) =>
-    o Sugar.EntityId -> m (EventMap (o GuiState.Update))
+recordDelEventMap :: _ => o Sugar.EntityId -> m (EventMap (o GuiState.Update))
 recordDelEventMap delete =
     Lens.view id
     <&>

--- a/src/Lamdu/GUI/Expr/TagEdit.hs
+++ b/src/Lamdu/GUI/Expr/TagEdit.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
 module Lamdu.GUI.Expr.TagEdit
     ( makeRecordTag, makeVariantTag
     , makeParamTag, addParamId
@@ -14,7 +13,6 @@ import           Data.MRUMemo (memo)
 import qualified Data.Property as Property
 import qualified Data.Text as Text
 import qualified GUI.Momentu as M
-import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
@@ -27,11 +25,8 @@ import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Menu as Menu
 import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import           Lamdu.Config.Theme.TextColors (TextColors)
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -44,7 +39,6 @@ import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.TagView as TagView
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Name as Name
@@ -54,14 +48,7 @@ import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-makePickEventMap ::
-    ( Functor f, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , MonadReader env m
-    ) =>
-    f Menu.PickResult ->
-    m (EventMap (f M.Update))
+makePickEventMap :: _ => f Menu.PickResult -> m (EventMap (f M.Update))
 makePickEventMap action =
     Lens.view id <&>
     \env ->
@@ -96,7 +83,7 @@ makeNewTag tagOpt =
         tagOpt ^. Sugar.toPick <&> mkPickResult (tagOpt ^. Sugar.toInfo . Sugar.tagInstance)
 
 makeNewTagPreEvent ::
-    (Has (Texts.CodeUI Text) env, Monad i, Monad o) =>
+    _ =>
     Sugar.TagOption Name o a ->
     GuiM env i o (Text -> (EntityId -> a -> r) -> Maybe (Widget.PreEvent (o r)))
 makeNewTagPreEvent tagOpt =
@@ -113,12 +100,7 @@ makeNewTagPreEvent tagOpt =
         }
 
 makeAddNewTag ::
-    ( Monad i, Monad o, MonadReader env f
-    , M.HasCursor env, Has Theme env
-    , Has TextView.Style env, M.HasAnimIdPrefix env, Has Dir.Layout env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.CodeUI Text) menv
-    ) =>
+    _ =>
     Sugar.TagOption Name o a ->
     GuiM menv i o
     ( (EntityId -> a -> Menu.PickResult) ->
@@ -150,14 +132,7 @@ fuzzyMaker :: [(Text, Int)] -> Fuzzy (Set Int)
 fuzzyMaker = memo Fuzzy.make
 
 makeOptions ::
-    ( Monad i, Monad o, MonadReader menv m
-    , M.HasCursor menv, Has Theme menv, Has TextView.Style menv
-    , M.HasAnimIdPrefix menv, Glue.HasTexts menv
-    , Has (Texts.Name Text) menv
-    , Has (Texts.CodeUI Text) menv
-    , Has (Texts.CodeUI Text) env
-    , Has (MomentuTexts.Texts Text) env
-    ) =>
+    _ =>
     Sugar.TagChoice Name i o a ->
     Sugar.TagOption Name o a ->
     (EntityId -> a -> Menu.PickResult) ->
@@ -226,11 +201,7 @@ allowedSearchTerm :: Text -> Bool
 allowedSearchTerm = Name.isValidText
 
 makeHoleSearchTerm ::
-    ( Monad i, Monad o
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     Sugar.TagOption Name o a ->
     (EntityId -> a -> Menu.PickResult) -> Widget.Id ->
     GuiM env i o (SearchMenu.Term o)
@@ -287,13 +258,7 @@ makeHoleSearchTerm newTagOption mkPickResult holeId =
         newTagId = newTagOption ^. Sugar.toInfo . Sugar.tagInstance & WidgetIds.fromEntityId & Widget.toAnimId
 
 makeTagHoleEdit ::
-    ( Monad i, Monad o
-    , Has (Texts.Name Text) env
-    , Has (Texts.CodeUI Text) env
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    ) =>
+    _ =>
     Sugar.TagChoice Name i o a ->
     (EntityId -> a -> Menu.PickResult) ->
     Widget.Id ->
@@ -306,16 +271,7 @@ makeTagHoleEdit tagRefReplace mkPickResult holeId =
             (makeOptions tagRefReplace newTagOption mkPickResult) M.empty holeId
             ?? Menu.AnyPlace
 
-makeTagRefEdit ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Sugar.TagRef Name i o ->
-    GuiM env i o (M.TextWidget o)
+makeTagRefEdit :: _ => Sugar.TagRef Name i o -> GuiM env i o (M.TextWidget o)
 makeTagRefEdit = makeTagRefEditWith id (const Nothing) <&> fmap snd
 
 data TagRefEditType
@@ -324,14 +280,7 @@ data TagRefEditType
     deriving (Eq)
 
 makeTagRefEditWith ::
-    ( Monad i, Monad o, MonadReader nenv n
-    , M.HasCursor nenv, Has TextView.Style nenv, Has (Texts.Name Text) nenv
-    , M.HasAnimIdPrefix nenv, Has Theme nenv, Glue.HasTexts nenv
-    , Glue.HasTexts env, TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Navigation Text) env
-    , Has (Texts.Name Text) env
-    ) =>
+    _ =>
     (n (M.TextWidget o) ->
      GuiM env i o (M.TextWidget o)) ->
     (Sugar.EntityId -> Maybe Widget.Id) ->
@@ -397,29 +346,11 @@ makeTagRefEditWith onView onPickNext tag =
             Just setAnon -> setAnon <&> fst <&> WidgetIds.fromEntityId
             <&> WidgetIds.tagHoleId
 
-makeRecordTag ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Sugar.TagRef Name i o ->
-    GuiM env i o (M.TextWidget o)
+makeRecordTag :: _ => Sugar.TagRef Name i o -> GuiM env i o (M.TextWidget o)
 makeRecordTag =
     makeTagRefEdit <&> Styled.withColor TextColors.recordTagColor
 
-makeVariantTag ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Sugar.TagRef Name i o ->
-    GuiM env i o (M.TextWidget o)
+makeVariantTag :: _ => Sugar.TagRef Name i o -> GuiM env i o (M.TextWidget o)
 makeVariantTag tag =
     makeTagRefEdit tag
     & Styled.withColor TextColors.caseTagColor
@@ -428,12 +359,7 @@ addParamId :: Widget.Id -> Widget.Id
 addParamId = (`Widget.joinId` ["add param"])
 
 makeLHSTag ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env, TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     (Sugar.EntityId -> Maybe Widget.Id) ->
     Lens.ALens' TextColors M.Color -> Sugar.TagRef Name i o ->
     GuiM env i o (M.TextWidget o)
@@ -468,26 +394,14 @@ makeLHSTag onPickNext color tag =
             Styled.nameAtBinder (tag ^. Sugar.tagRefTag . Sugar.tagName) .
             Styled.withColor color
 
-makeParamTag ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env, TextEdit.HasTexts env, SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    Sugar.TagRef Name i o ->
-    GuiM env i o (M.TextWidget o)
+makeParamTag :: _ => Sugar.TagRef Name i o -> GuiM env i o (M.TextWidget o)
 makeParamTag =
     makeLHSTag onPickNext TextColors.parameterColor
     where
         onPickNext pos = WidgetIds.fromEntityId pos & addParamId & Just
 
 -- | Unfocusable tag view (e.g: in apply args)
-makeArgTag ::
-    ( MonadReader env m, Has Theme env, Has TextView.Style env
-    , M.HasAnimIdPrefix env, Glue.HasTexts env, Has (Texts.Name Text) env
-    ) =>
-    Name -> Sugar.EntityId -> m (M.WithTextPos M.View)
+makeArgTag :: _ => Name -> Sugar.EntityId -> m (M.WithTextPos M.View)
 makeArgTag name tagInstance =
     NameView.make name
     & Styled.withColor TextColors.argTagColor
@@ -496,14 +410,7 @@ makeArgTag name tagInstance =
         animId = WidgetIds.fromEntityId tagInstance & Widget.toAnimId
 
 makeBinderTagEdit ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , TextEdit.HasTexts env
-    , SearchMenu.HasTexts env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
+    _ =>
     Lens.ALens' TextColors M.Color -> Sugar.TagRef Name i o ->
     GuiM env i o (M.TextWidget o)
 makeBinderTagEdit color tag =

--- a/src/Lamdu/GUI/Monad.hs
+++ b/src/Lamdu/GUI/Monad.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, TemplateHaskell #-}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DerivingVia #-}
 {-# LANGUAGE UndecidableInstances, PolymorphicComponents #-}
+
 module Lamdu.GUI.Monad
     ( StoredEntityIds(..)
     --
@@ -59,7 +60,7 @@ import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import           Lamdu.I18N.LangId (LangId)
 import           Lamdu.Settings (Settings)
-import           Lamdu.Style (Style, HasStyle)
+import           Lamdu.Style (Style)
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
@@ -192,10 +193,7 @@ withLocalIsHoleResult :: MonadReader (Askable env i o) m => m a -> m a
 withLocalIsHoleResult = Reader.local (aIsHoleResult .~ True)
 
 run ::
-    ( GuiState.HasState env, Spacer.HasStdSpacing env, Has Dir.Layout env
-    , Has Config env, Has Theme env
-    , Has Settings env, HasStyle env
-    ) =>
+    _ =>
     (T.Tag -> MkProperty' o Text) ->
     (ExprGui.Expr Sugar.Term i o -> GuiM env i o (Responsive o)) ->
     (ExprGui.Expr Sugar.Binder i o -> GuiM env i o (Responsive o)) ->

--- a/src/Lamdu/GUI/NameView.hs
+++ b/src/Lamdu/GUI/NameView.hs
@@ -6,28 +6,23 @@ import qualified Control.Lens as Lens
 import qualified Control.Monad.Reader as Reader
 import           GUI.Momentu.Align (Aligned(..), WithTextPos(..))
 import qualified GUI.Momentu.Align as Align
-import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Draw as Draw
 import qualified GUI.Momentu.Element as Element
 import qualified GUI.Momentu.Glue as Glue
 import           GUI.Momentu.View (View)
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.Name as NameTheme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import qualified Lamdu.GUI.Styled as Styled
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Name as Name
 
 import           Lamdu.Prelude
 
 makeCollisionSuffixLabel ::
-    ( MonadReader env m, Has Dir.Layout env
-    , Has TextView.Style env, Element.HasAnimIdPrefix env, Has Theme env
-    ) => Lens.ALens' NameTheme.Name Draw.Color -> Name.Collision -> m (Maybe View)
+    _ => Lens.ALens' NameTheme.Name Draw.Color -> Name.Collision -> m (Maybe View)
 makeCollisionSuffixLabel collisionColor mCollision =
     case mCollision of
     Name.NoCollision -> pure Nothing
@@ -45,12 +40,7 @@ makeCollisionSuffixLabel collisionColor mCollision =
             <&> (^. Align.tValue)
             <&> Just
 
-make ::
-    ( MonadReader env m
-    , Has Theme env, Element.HasAnimIdPrefix env, Has TextView.Style env
-    , Has Dir.Layout env, Has (Texts.Name Text) env
-    ) =>
-    Name -> m (WithTextPos View)
+make :: _ => Name -> m (WithTextPos View)
 make name =
     do
         (Name.TagText visibleName textCollision, tagCollision) <- Name.visible name

--- a/src/Lamdu/GUI/ParamEdit.hs
+++ b/src/Lamdu/GUI/ParamEdit.hs
@@ -9,7 +9,6 @@ import           GUI.Momentu.Align (TextWidget)
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.MetaKey (MetaKey, toModKey)
 import           GUI.Momentu.Responsive (Responsive)
@@ -17,8 +16,6 @@ import qualified GUI.Momentu.Responsive as Responsive
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Menu as Menu
-import qualified GUI.Momentu.Widgets.Menu.Search as SearchMenu
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import qualified Lamdu.Config.Theme.TextColors as TextColors
@@ -27,22 +24,14 @@ import qualified Lamdu.GUI.Annotation as Annotation
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Code as Texts
 import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
 eventMapAddFirstParam ::
-    ( MonadReader env m, Applicative o, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
-    Widget.Id ->
-    Sugar.AddFirstParam name i o ->
-    m (EventMap (o GuiState.Update))
+    _ => Widget.Id -> Sugar.AddFirstParam name i o -> m (EventMap (o GuiState.Update))
 eventMapAddFirstParam binderId addFirst =
     Lens.view id
     <&>
@@ -61,13 +50,7 @@ eventMapAddFirstParam binderId addFirst =
                 (x <&> enterParam, Texts.addParameter)
 
 eventMapAddNextParam ::
-    ( Applicative o
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has Config env
-    ) =>
-    env -> Widget.Id -> Sugar.AddNextParam name i o ->
-    EventMap (o GuiState.Update)
+    _ => env -> Widget.Id -> Sugar.AddNextParam name i o -> EventMap (o GuiState.Update)
 eventMapAddNextParam env myId addNext =
     E.keysEventMapMovesCursor (env ^. has . Config.addNextParamKeys)
     (E.toDoc env [has . MomentuTexts.edit, has . doc]) (pure dst)
@@ -82,11 +65,7 @@ eventMapAddNextParam env myId addNext =
                 )
 
 eventMapOrderParam ::
-    ( Monad m
-    , Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     env ->
     Lens.ALens' Config [MetaKey] ->
     Lens.ALens' (Texts.CodeUI Text) Text -> m () ->
@@ -97,10 +76,7 @@ eventMapOrderParam env keys moveDoc =
         [has . MomentuTexts.edit, has . Texts.parameter, has . moveDoc])
 
 eventParamDelEventMap ::
-    ( Monad m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     env -> m () ->
     Lens.ALens' Config [MetaKey] ->
     Lens.ALens' (Texts.CodeUI Text) Text -> Widget.Id -> EventMap (m GuiState.Update)
@@ -128,13 +104,7 @@ mkParamPickResult tagInstance _ =
 
 -- exported for use in definition sugaring.
 make ::
-    ( Monad i, Monad o
-    , Has (TextEdit.Texts Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Code Text) env
-    , Glue.HasTexts env, SearchMenu.HasTexts env
-    ) =>
+    _ =>
     Annotation.EvalAnnotationOptions ->
     Widget.Id -> Widget.Id ->
     (Sugar.FuncParam (Sugar.Annotation (Sugar.EvaluationScopes Name i) Name) Name, Info i o) ->

--- a/src/Lamdu/GUI/PresentationModeEdit.hs
+++ b/src/Lamdu/GUI/PresentationModeEdit.hs
@@ -9,13 +9,9 @@ import qualified Control.Monad.Reader as Reader
 import           Data.Property (Property)
 import qualified GUI.Momentu.Align as Align
 import qualified GUI.Momentu.Element as Element
-import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
-import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Choice as Choice
 import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import qualified Lamdu.GUI.Styled as Styled
@@ -32,13 +28,7 @@ lens mode =
 
 {-# ANN make ("HLint: ignore Use head"::String) #-}
 make ::
-    ( Applicative f, MonadReader env m, Has Theme env
-    , Element.HasAnimIdPrefix env, Has TextView.Style env, GuiState.HasCursor env
-    , Has Hover.Style env
-    , Has (Texts.CodeUI Text) env
-    , Has (Choice.Texts Text) env
-    , Glue.HasTexts env
-    ) =>
+    _ =>
     Widget.Id ->
     Sugar.BinderParams v name i o ->
     Property f Sugar.PresentationMode ->

--- a/src/Lamdu/GUI/Settings.hs
+++ b/src/Lamdu/GUI/Settings.hs
@@ -11,24 +11,16 @@ import qualified Control.Lens as Lens
 import           Data.Property (Property, composeLens)
 import           GUI.Momentu.Align (WithTextPos(..))
 import qualified GUI.Momentu.Animation.Id as AnimId
-import           GUI.Momentu.Draw (Sprite)
 import qualified GUI.Momentu.Element as Element
-import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
 import qualified GUI.Momentu.I18N as Texts
 import qualified GUI.Momentu.State as GuiState
 import qualified GUI.Momentu.Widget.Id as WidgetId
-import qualified GUI.Momentu.Widgets.Choice as Choice
 import           GUI.Momentu.Widgets.EventMapHelp (IsHelpShown(..))
-import           GUI.Momentu.Widgets.Spacer (HasStdSpacing)
 import qualified GUI.Momentu.Widgets.TextView as TextView
 import qualified Lamdu.Annotations as Ann
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import           Lamdu.Config.Folder (Selection)
 import qualified Lamdu.Config.Folder as Folder
-import           Lamdu.Config.Theme (Theme)
-import           Lamdu.Config.Theme.Sprites (Sprites)
 import qualified Lamdu.Config.Theme.Sprites as Sprites
 import qualified Lamdu.GUI.StatusBar.Common as StatusBar
 import           Lamdu.GUI.Styled (OneOfT(..), info, label)
@@ -62,18 +54,7 @@ hoist f (StatusWidgets x y z a) =
     where
         h = StatusBar.hoist f
 
-makeAnnotationsSwitcher ::
-    ( MonadReader env m, Applicative f
-    , Has Config env
-    , Has TextView.Style env
-    , Has (Texts.StatusBar Text) env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Sprites Sprite) env
-    , Glue.HasTexts env
-    , Element.HasAnimIdPrefix env, GuiState.HasCursor env, Has Hover.Style env
-    ) =>
-    Property f Ann.Mode -> m (StatusBar.StatusWidget f)
+makeAnnotationsSwitcher :: _ => Property f Ann.Mode -> m (StatusBar.StatusWidget f)
 makeAnnotationsSwitcher annotationModeProp =
     do
         mk0 <- Styled.mkFocusableLabel
@@ -88,15 +69,7 @@ makeAnnotationsSwitcher annotationModeProp =
             Config.nextAnnotationModeKeys annotationModeProp
 
 makeStatusWidgets ::
-    ( MonadReader env m, Applicative f
-    , Has Config env, Has Theme env, HasStdSpacing env
-    , Element.HasAnimIdPrefix env, GuiState.HasCursor env, Has Hover.Style env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.StatusBar Text) env
-    , Has (Sprites Sprite) env
-    , Glue.HasTexts env
-    ) =>
+    (MonadReader env m, _) =>
     [TitledSelection Folder.Theme] -> [TitledSelection Folder.Language] ->
     Property f Settings -> m (StatusWidgets f)
 makeStatusWidgets themeNames langNames prop =

--- a/src/Lamdu/GUI/StatusBar.hs
+++ b/src/Lamdu/GUI/StatusBar.hs
@@ -9,23 +9,10 @@ import qualified Control.Lens as Lens
 import           Control.Monad.Transaction (MonadTransaction(..))
 import           Data.Property (Property)
 import           Data.Vector.Vector2 (Vector2(..))
-import qualified GUI.Momentu.Align as Align
-import           GUI.Momentu.Draw (Sprite)
-import qualified GUI.Momentu.Draw as Draw
+import qualified GUI.Momentu as M
 import qualified GUI.Momentu.Element as Element
-import           GUI.Momentu.Glue ((/|/))
-import qualified GUI.Momentu.Hover as Hover
-import qualified GUI.Momentu.State as GuiState
-import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.Choice as Choice
-import qualified GUI.Momentu.Widgets.Grid as Grid
-import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config.Folder as Folder
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
-import           Lamdu.Config.Theme.Sprites (Sprites)
 import           Lamdu.GUI.IOTrans (IOTrans(..))
 import qualified Lamdu.GUI.IOTrans as IOTrans
 import           Lamdu.GUI.Settings (TitledSelection(..), title, selection)
@@ -34,38 +21,24 @@ import           Lamdu.GUI.StatusBar.Common
 import qualified Lamdu.GUI.StatusBar.Common as StatusBar
 import           Lamdu.GUI.Styled (info, label)
 import qualified Lamdu.GUI.VersionControl as VersionControlGUI
-import qualified Lamdu.GUI.VersionControl.Config as VCConfig
-import qualified Lamdu.I18N.CodeUI as Texts
 import qualified Lamdu.I18N.StatusBar as Texts
-import qualified Lamdu.I18N.Versioning as Texts
 import           Lamdu.Settings (Settings)
 import qualified Lamdu.VersionControl.Actions as VCActions
 
 import           Lamdu.Prelude
 
 make ::
-    ( MonadReader env m, MonadTransaction n m
-    , TextEdit.Deps env, Has Theme env, Has Hover.Style env
-    , GuiState.HasState env, Element.HasAnimIdPrefix env
-    , Grid.HasTexts env
-    , Has VCConfig.Config env, Has VCConfig.Theme env, Spacer.HasStdSpacing env
-    , Has Config env
-    , Has (Sprites Sprite) env
-    , Has (Texts.StatusBar Text) env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.Versioning Text) env
-    , Has (Texts.CodeUI Text) env
-    ) =>
+    _ =>
     StatusWidget (IOTrans n) ->
     [TitledSelection Folder.Theme] -> [TitledSelection Folder.Language] ->
     Property IO Settings ->
-    Widget.R -> VCActions.Actions n (IOTrans n) ->
+    Double -> VCActions.Actions n (IOTrans n) ->
     m (StatusWidget (IOTrans n))
 make gotoDefinition themeNames langNames settingsProp width vcActions =
     do
         branchSelector <-
             info (label Texts.sbBranch)
-            /|/ VersionControlGUI.makeBranchSelector IOTrans.liftTrans
+            M./|/ VersionControlGUI.makeBranchSelector IOTrans.liftTrans
                 transaction vcActions
             <&> StatusBar.fromWidget
 
@@ -75,7 +48,7 @@ make gotoDefinition themeNames langNames settingsProp width vcActions =
 
         theTheme <- Lens.view has
         bgColor <-
-            Draw.backgroundColor ?? theTheme ^. Theme.statusBar . Theme.statusBarBGColor
+            M.backgroundColor ?? theTheme ^. Theme.statusBar . Theme.statusBarBGColor
         padToSize <- Element.padToSize
         (StatusBar.combineEdges ?? width ?? gotoDefinition)
             <*> ( StatusBar.combine ??
@@ -86,5 +59,5 @@ make gotoDefinition themeNames langNames settingsProp width vcActions =
                     , statusWidgets ^. SettingsGui.helpWidget
                     ]
                 )
-            <&> StatusBar.widget . Align.tValue %~ padToSize (Vector2 width 0) 0
+            <&> StatusBar.widget . M.tValue %~ padToSize (Vector2 width 0) 0
             <&> StatusBar.widget %~ bgColor

--- a/src/Lamdu/GUI/StatusBar/Common.hs
+++ b/src/Lamdu/GUI/StatusBar/Common.hs
@@ -1,9 +1,8 @@
 -- | Common utilities for status bar widgets
 {-# LANGUAGE TemplateHaskell, RankNTypes, TypeFamilies #-}
-{-# LANGUAGE ConstraintKinds #-}
+
 module Lamdu.GUI.StatusBar.Common
     ( StatusWidget(..), widget, globalEventMap
-    , LabelConstraints
     , hoist
     , makeSwitchStatusWidget
     , fromWidget, combine, combineEdges
@@ -14,19 +13,14 @@ import           Control.Lens.Extended (OneOf)
 import           Data.Property (Property(..))
 import qualified GUI.Momentu as M
 import           GUI.Momentu.Animation.Id (ElemIds(..))
-import qualified GUI.Momentu.Direction as Dir
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
 import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
 import           GUI.Momentu.MetaKey (MetaKey)
 import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.Choice as Choice
-import           GUI.Momentu.Widgets.Spacer (HasStdSpacing)
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextView as TextView
 import           Lamdu.Config (Config)
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.I18N.StatusBar as Texts
 
@@ -56,22 +50,7 @@ fromWidget :: M.TextWidget f -> StatusWidget f
 fromWidget w =
     StatusWidget { _widget = w, _globalEventMap = mempty }
 
-type LabelConstraints env m =
-    ( MonadReader env m, Has TextView.Style env, Has Theme env
-    , M.HasAnimIdPrefix env, Has (Texts.StatusBar Text) env
-    , Has Dir.Layout env
-    )
-
-makeChoice ::
-    ( MonadReader env m, Applicative f, Eq a
-    , Has Hover.Style env, M.HasCursor env
-    , M.HasAnimIdPrefix env
-    , Has (Choice.Texts Text) env
-    , Has (t Text) env, ElemIds t
-    , Glue.HasTexts env
-    ) =>
-    OneOf t -> Property f a ->
-    [(a, M.TextWidget f)] -> m (M.TextWidget f)
+makeChoice :: _ => OneOf t -> Property f a -> [(a, M.TextWidget f)] -> m (M.TextWidget f)
 makeChoice headerText prop choices =
     do
         defConf <- Choice.defaultConfig
@@ -81,27 +60,12 @@ makeChoice headerText prop choices =
         myId = Widget.Id ("status" : elemIds ^# headerText)
 
 labeledChoice ::
-    ( MonadReader env m, Applicative f, Eq a
-    , M.HasAnimIdPrefix env
-    , M.HasCursor env, Has Hover.Style env
-    , Has (Choice.Texts Text) env
-    , Has (t Text) env, ElemIds t
-    , Glue.HasTexts env
-    ) =>
-    M.WithTextPos M.View -> OneOf t -> Property f a -> [(a, M.TextWidget f)] -> m (M.TextWidget f)
+    _ => M.WithTextPos M.View -> OneOf t -> Property f a -> [(a, M.TextWidget f)] -> m (M.TextWidget f)
 labeledChoice headerView categoryTextLens prop choices =
     pure headerView M./|/ makeChoice categoryTextLens prop choices
 
 makeSwitchStatusWidget ::
-    ( MonadReader env m, Applicative f, Eq a
-    , Has Config env
-    , M.HasAnimIdPrefix env, M.HasCursor env
-    , Has Hover.Style env
-    , Has (Choice.Texts Text) env
-    , Has (Texts.StatusBar Text) env
-    , Has (t Text) env, ElemIds t
-    , Glue.HasTexts env
-    ) =>
+    _ =>
     m (M.WithTextPos M.View) -> OneOf t -> OneOf Texts.StatusBar -> Lens' Config [MetaKey] -> Property f a ->
     [(a, M.TextWidget f)] -> m (StatusWidget f)
 makeSwitchStatusWidget mkHeaderWidget categoryTextLens switchTextLens keysGetter prop choiceVals =
@@ -126,16 +90,12 @@ makeSwitchStatusWidget mkHeaderWidget categoryTextLens switchTextLens keysGetter
         newVal = dropWhile (/= curVal) choices ++ choices & tail & head
         Property curVal setVal = prop
 
-hspacer ::
-    (MonadReader env m, Spacer.HasStdSpacing env, Has Theme env) => m M.View
+hspacer :: _ => m M.View
 hspacer = do
     hSpaceCount <- Lens.view (has . Theme.statusBar . Theme.statusBarHSpaces)
     Spacer.getSpaceSize <&> (^. _1) <&> (* hSpaceCount) <&> Spacer.makeHorizontal
 
-combine ::
-    ( MonadReader env m, Applicative f, HasStdSpacing env, Has Theme env
-    , Glue.HasTexts env
-    ) => m ([StatusWidget f] -> StatusWidget f)
+combine :: _ => m ([StatusWidget f] -> StatusWidget f)
 combine =
     (,,) <$> (Glue.mkPoly ?? Glue.Horizontal) <*> Glue.hbox <*> hspacer
     <&> \(Glue.Poly (|||), hbox, space) statusWidgets ->
@@ -152,9 +112,7 @@ combine =
     , _globalEventMap = statusWidgets ^. Lens.folded . globalEventMap
     }
 
-combineEdges ::
-    (MonadReader env m, Applicative f, Glue.HasTexts env) =>
-    m (Double -> StatusWidget f -> StatusWidget f -> StatusWidget f)
+combineEdges :: _ => m (Double -> StatusWidget f -> StatusWidget f -> StatusWidget f)
 combineEdges =
     Glue.mkPoly ?? Glue.Horizontal
     <&> \(Glue.Poly (|||)) width (StatusWidget xw xe) (StatusWidget yw ye) ->

--- a/src/Lamdu/GUI/TagPane.hs
+++ b/src/Lamdu/GUI/TagPane.hs
@@ -11,12 +11,9 @@ import qualified Data.Property as Property
 import qualified Data.Set as Set
 import           GUI.Momentu.Align (TextWidget, Aligned(..), WithTextPos(..))
 import qualified GUI.Momentu.Align as Align
-import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Element as Element
 import qualified GUI.Momentu.EventMap as E
 import           GUI.Momentu.Glue ((/-/), (/|/))
-import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.MetaKey (MetaKey(..), noMods)
 import qualified GUI.Momentu.MetaKey as MetaKey
@@ -27,12 +24,10 @@ import qualified GUI.Momentu.Widgets.Choice as Choice
 import qualified GUI.Momentu.Widgets.FocusDelegator as FocusDelegator
 import qualified GUI.Momentu.Widgets.Grid as Grid
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextEdit as TextEdit
 import qualified GUI.Momentu.Widgets.TextEdit.Property as TextEdits
 import qualified GUI.Momentu.Widgets.TextView as TextView
 import qualified Lamdu.CharClassification as Chars
 import qualified Lamdu.Config as Config
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import           Lamdu.Data.Tag (TextsInLang(..))
 import qualified Lamdu.Data.Tag as Tag
@@ -51,12 +46,7 @@ tagRenameId = (`Widget.joinId` ["rename"])
 disallowedNameChars :: Set Char
 disallowedNameChars = Set.fromList ",[]\\`()"
 
-makeTagNameEdit ::
-    ( MonadReader env m, Applicative f
-    , TextEdit.Deps env, GuiState.HasCursor env
-    ) =>
-    Property f Text -> Widget.Id ->
-    m (TextWidget f)
+makeTagNameEdit :: _ => Property f Text -> Widget.Id -> m (TextWidget f)
 makeTagNameEdit prop myId =
     TextEdits.makeWordEdit
     ?? pure "  "
@@ -64,13 +54,7 @@ makeTagNameEdit prop myId =
     ?? tagRenameId myId
     <&> Align.tValue . Widget.eventMapMaker . Lens.mapped %~ E.filterChars (`Set.notMember` disallowedNameChars)
 
-makeSymbolNameEdit ::
-    ( MonadReader env m, Applicative f
-    , Has (Texts.CodeUI Text) env
-    , TextEdit.Deps env, GuiState.HasCursor env
-    ) =>
-    Property f Text -> Widget.Id ->
-    m (TextWidget f)
+makeSymbolNameEdit :: _ => Property f Text -> Widget.Id -> m (TextWidget f)
 makeSymbolNameEdit prop myId =
     TextEdits.makeWordEdit
     <*> (Lens.view (has . Texts.typeOperatorHere) <&> pure)
@@ -82,15 +66,7 @@ makeSymbolNameEdit prop myId =
             Set.member
             ?? Set.fromList Chars.operator `Set.difference` disallowedNameChars
 
-makeFocusableTagNameEdit ::
-    ( MonadReader env m
-    , Applicative o
-    , Has (Texts.CodeUI Text) env
-    , TextEdit.Deps env
-    , GuiState.HasCursor env
-    , Has Config.Config env
-    ) =>
-    Widget.Id -> Property o Text -> m (TextWidget o)
+makeFocusableTagNameEdit :: _ => Widget.Id -> Property o Text -> m (TextWidget o)
 makeFocusableTagNameEdit myId prop =
     do
         env <- Lens.view id
@@ -118,12 +94,7 @@ makeFocusableTagNameEdit myId prop =
             <&> (Align.tValue %~))
             <*> makeTagNameEdit prop myId
 
-makeLanguageTitle ::
-    ( MonadReader env m
-    , Has TextView.Style env, Has Dir.Layout env
-    , Has (Map LangId Text) env
-    ) =>
-    Widget.Id -> LangId -> m (TextWidget o)
+makeLanguageTitle :: _ => Widget.Id -> LangId -> m (TextWidget o)
 makeLanguageTitle myId lang =
     TextView.make
     <*> (Lens.view has <&> getLang)
@@ -152,12 +123,12 @@ langWidgetId parentId lang =
 nameId :: Widget.Id -> Widget.Id
 nameId = (`Widget.joinId` ["name"])
 
-hspace :: (MonadReader env m, Spacer.HasStdSpacing env) => m (TextWidget f)
+hspace :: _ => m (TextWidget f)
 hspace =
     Spacer.stdHSpace <&> WithTextPos 0 <&> Align.tValue %~ Widget.fromView
 
 textsRow ::
-    (MonadReader env m, Spacer.HasStdSpacing env, Functor f) =>
+    _ =>
     m (TextWidget f) ->
     m (TextWidget f) ->
     m (TextWidget f) ->
@@ -169,12 +140,7 @@ textsRow lang name abbrev disambig =
     <&> Lens.mapped %~ Align.fromWithTextPos 0
 
 makeLangRow ::
-    ( Applicative o
-    , MonadReader env m
-    , Spacer.HasStdSpacing env
-    , Has Theme env, Has (Map LangId Text) env, Has (Texts.CodeUI Text) env
-    , TextEdit.Deps env, GuiState.HasCursor env, Has Config.Config env
-    ) =>
+    _ =>
     Widget.Id -> (LangId -> TextsInLang -> o ()) -> LangId -> TextsInLang ->
     m (TextsRow (Aligned (Widget o)))
 makeLangRow parentId setName lang langNames =
@@ -195,11 +161,7 @@ makeLangRow parentId setName lang langNames =
             & Property (langNames ^. Lens.cloneLens l . Lens._Just)
 
 makeMissingLangRow ::
-    ( Applicative o
-    , MonadReader env m, Spacer.HasStdSpacing env, Has Theme env
-    , Has (Map LangId Text) env, Has (Texts.CodeUI Text) env
-    , TextEdit.Deps env, GuiState.HasCursor env, Has Config.Config env
-    ) =>
+    _ =>
     Widget.Id -> (LangId -> TextsInLang -> o ()) -> LangId ->
     m (TextsRow (Aligned (Widget o)))
 makeMissingLangRow parentId setName lang =
@@ -215,15 +177,7 @@ makeMissingLangRow parentId setName lang =
             & Property ""
 
 makeLangsTable ::
-    ( MonadReader env m
-    , Applicative o
-    , Has (Texts.CodeUI Text) env, Has (Grid.Texts Text) env, Has Theme env
-    , TextEdit.Deps env, Glue.HasTexts env
-    , GuiState.HasCursor env
-    , Element.HasAnimIdPrefix env, Has Config.Config env
-    , Spacer.HasStdSpacing env
-    , Has LangId env, Has (Map LangId Text) env
-    ) =>
+    (MonadReader env m, _) =>
     Widget.Id -> Map LangId TextsInLang ->
     (LangId -> TextsInLang -> o ()) -> m (Widget o)
 makeLangsTable myId tagTexts setName =
@@ -256,18 +210,7 @@ makeLangsTable myId tagTexts setName =
 data SymType = NoSymbol | UniversalSymbol | DirectionalSymbol
     deriving Eq
 
-makeSymbol ::
-    ( MonadReader env m
-    , Applicative o
-    , Has Theme env
-    , Has (Texts.CodeUI Text) env
-    , Has (Choice.Texts Text) env, Has Hover.Style env
-    , TextEdit.Deps env, Glue.HasTexts env
-    , GuiState.HasCursor env
-    , Element.HasAnimIdPrefix env
-    , Spacer.HasStdSpacing env
-    ) =>
-    Widget.Id -> Property o Tag.Symbol -> m (TextWidget o)
+makeSymbol :: _ => Widget.Id -> Property o Tag.Symbol -> m (TextWidget o)
 makeSymbol myId symProp =
     case symProp ^. pVal of
     Tag.NoSymbol -> makeChoice NoSymbol (toSym "" "")
@@ -309,18 +252,7 @@ makeSymbol myId symProp =
                     ?? defConf ?? mkId "symType"
                 & withColor TextColors.actionTextColor
 
-make ::
-    ( MonadReader env m
-    , Applicative o
-    , Has (Texts.CodeUI Text) env, Has (Grid.Texts Text) env
-    , Has (Choice.Texts Text) env, Has Hover.Style env
-    , TextEdit.Deps env, Glue.HasTexts env
-    , GuiState.HasCursor env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has Config.Config env
-    , Spacer.HasStdSpacing env
-    , Has LangId env, Has (Map LangId Text) env
-    ) =>
-    Sugar.TagPane Name o -> m (Widget o)
+make :: _ => Sugar.TagPane Name o -> m (Widget o)
 make tagPane =
     addValFrame <*>
     do

--- a/src/Lamdu/GUI/TagView.hs
+++ b/src/Lamdu/GUI/TagView.hs
@@ -5,29 +5,19 @@ module Lamdu.GUI.TagView
     ) where
 
 import qualified Control.Monad.Reader as Reader
-import           GUI.Momentu.Align (WithTextPos)
-import qualified GUI.Momentu.Direction as Dir
-import qualified GUI.Momentu.Element as Element
-import           GUI.Momentu.View (View)
+import qualified GUI.Momentu as M
 import qualified GUI.Momentu.Widget as Widget
-import qualified GUI.Momentu.Widgets.TextView as TextView
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.GUI.NameView as NameView
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name(..))
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-make ::
-    ( MonadReader env m, Has TextView.Style env, Element.HasAnimIdPrefix env
-    , Has Theme env, Has Dir.Layout env, Has (Texts.Name Text) env
-    ) =>
-    Sugar.Tag Name -> m (WithTextPos View)
+make :: _ => Sugar.Tag Name -> m (M.WithTextPos M.View)
 make tag =
     NameView.make (tag ^. Sugar.tagName)
-    & Reader.local (Element.animIdPrefix .~ animId)
+    & Reader.local (M.animIdPrefix .~ animId)
     where
         animId =
             tag ^. Sugar.tagInstance

--- a/src/Lamdu/GUI/TypeView.hs
+++ b/src/Lamdu/GUI/TypeView.hs
@@ -12,7 +12,6 @@ import           GUI.Momentu.Align (Aligned(..), WithTextPos(..))
 import qualified GUI.Momentu.Align as Align
 import qualified GUI.Momentu.Direction as Dir
 import qualified GUI.Momentu.Draw as MDraw
-import           GUI.Momentu.Element (Element)
 import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.Glue ((/-/), (/|/))
 import qualified GUI.Momentu.Glue as Glue
@@ -22,9 +21,7 @@ import qualified GUI.Momentu.Widget as Widget
 import qualified GUI.Momentu.Widgets.GridView as GridView
 import qualified GUI.Momentu.Widgets.Label as Label
 import qualified GUI.Momentu.Widgets.Spacer as Spacer
-import qualified GUI.Momentu.Widgets.TextView as TextView
 import           Hyper.Type.AST.FuncType (FuncType(..))
-import           Lamdu.Config.Theme (Theme)
 import qualified Lamdu.Config.Theme as Theme
 import qualified Lamdu.Config.Theme.TextColors as TextColors
 import qualified Lamdu.GUI.NameView as NameView
@@ -32,7 +29,6 @@ import qualified Lamdu.GUI.Styled as Styled
 import qualified Lamdu.GUI.TagView as TagView
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
 import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name)
 import qualified Lamdu.Sugar.Types as Sugar
 
@@ -63,38 +59,23 @@ horizSetCompositeRow r =
 sanitize :: Text -> Text
 sanitize = Text.replace "\0" ""
 
-grammar ::
-    ( MonadReader env m, Has TextView.Style env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has Dir.Layout env
-    ) =>
-    Text -> m (WithTextPos View)
+grammar :: _ => Text -> m (WithTextPos View)
 grammar = Styled.grammar . Label.make . sanitize
 
-parensAround ::
-    ( MonadReader env m, Has TextView.Style env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has Dir.Layout env
-    ) =>
-    WithTextPos View -> m (WithTextPos View)
+parensAround :: _ => WithTextPos View -> m (WithTextPos View)
 parensAround view =
     do
         openParenView <- grammar "("
         closeParenView <- grammar ")"
         Glue.hbox Dir.LeftToRight [openParenView, view, closeParenView] & pure
 
-parens ::
-    ( MonadReader env m, Has TextView.Style env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has Dir.Layout env
-    ) =>
-    Prec -> Prec -> WithTextPos View -> m (WithTextPos View)
+parens :: _ => Prec -> Prec -> WithTextPos View -> m (WithTextPos View)
 parens parent my view
     | parent > my = parensAround view
     | otherwise = pure view
 
 makeTFun ::
-    ( MonadReader env m, Has Theme env, Spacer.HasStdSpacing env
-    , Element.HasAnimIdPrefix env, Glue.HasTexts env
-    , Has (Texts.Code Text) env, Has (Texts.Name Text) env
-    ) =>
+    _ =>
     Prec ->
     Annotated Sugar.EntityId # Sugar.Type Name ->
     Annotated Sugar.EntityId # Sugar.Type Name ->
@@ -115,10 +96,7 @@ makeTFun parentPrecedence a b =
     ) >>= parens parentPrecedence (Prec 0)
 
 makeTInst ::
-    ( MonadReader env m, Spacer.HasStdSpacing env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has (Texts.Name Text) env
-    , Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
+    (MonadReader env m, _) =>
     Prec -> Sugar.TId Name ->
     [(Name, Annotated Sugar.EntityId # Sugar.Type Name)] ->
     m (WithTextPos View)
@@ -154,9 +132,7 @@ makeTInst parentPrecedence tid typeParams =
         disambAnimId suffixes =
             Reader.local (Element.animIdPrefix <>~ (suffixes <&> BS8.pack))
 
-addTypeBG ::
-    (Element a, MonadReader env m, Has Theme env, Element.HasAnimIdPrefix env) =>
-    a -> m a
+addTypeBG :: _ => a -> m a
 addTypeBG view =
     do
         color <- Lens.view (has . Theme.typeFrameBGColor)
@@ -165,18 +141,11 @@ addTypeBG view =
             & MDraw.backgroundColor bgId color
             & pure
 
-makeEmptyComposite ::
-    ( MonadReader env m, Has TextView.Style env, Has Theme env
-    , Element.HasAnimIdPrefix env, Has Dir.Layout env
-    ) =>
-    m (WithTextPos View)
+makeEmptyComposite :: _ => m (WithTextPos View)
 makeEmptyComposite = grammar "Ø"
 
 makeField ::
-    ( MonadReader env m, Has Theme env
-    , Spacer.HasStdSpacing env, Element.HasAnimIdPrefix env
-    , Has (Texts.Name Text) env, Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
+    _ =>
     (Sugar.Tag Name, Annotated Sugar.EntityId # Sugar.Type Name) ->
     m (WithTextPos View, WithTextPos View)
 makeField (tag, fieldType) =
@@ -185,21 +154,14 @@ makeField (tag, fieldType) =
     <*> makeInternal (Prec 0) fieldType
 
 makeVariantField ::
-    ( MonadReader env m, Spacer.HasStdSpacing env
-    , Has Theme env, Element.HasAnimIdPrefix env
-    , Has (Texts.Name Text) env, Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
+    _ =>
     (Sugar.Tag Name, Annotated Sugar.EntityId # Sugar.Type Name) ->
     m (WithTextPos View, WithTextPos View)
 makeVariantField (tag, Ann _ (Sugar.TRecord (Sugar.CompositeFields [] Nothing))) =
     TagView.make tag <&> (, Element.empty)
 makeVariantField (tag, fieldType) = makeField (tag, fieldType)
 
-gridViewTopLeftAlign ::
-    ( MonadReader env m, Has Dir.Layout env
-    , Traversable vert, Traversable horiz
-    ) =>
-    m (vert (horiz (Aligned View)) -> Aligned View)
+gridViewTopLeftAlign :: _ => m (vert (horiz (Aligned View)) -> Aligned View)
 gridViewTopLeftAlign =
     GridView.make <&>
     \mkGrid views ->
@@ -209,10 +171,7 @@ gridViewTopLeftAlign =
         Just x -> x & Align.value .~ view
 
 makeComposite ::
-    ( MonadReader env m, Has Theme env, Spacer.HasStdSpacing env
-    , Element.HasAnimIdPrefix env, Has Dir.Layout env
-    , Has (Texts.Name Text) env, Has (Texts.Code Text) env
-    ) =>
+    _ =>
     m (WithTextPos View) -> m (WithTextPos View) -> m (WithTextPos View) ->
     ((Sugar.Tag Name, Annotated Sugar.EntityId # Sugar.Type Name) ->
          m (WithTextPos View, WithTextPos View)) ->
@@ -260,13 +219,7 @@ makeComposite mkOpener mkPre mkPost mkField composite =
                     | v ^. Align.tValue . Element.width == 0 = pure Element.empty
                     | otherwise = Spacer.stdHSpace <&> WithTextPos 0
 
-makeInternal ::
-    ( MonadReader env m, Spacer.HasStdSpacing env, Has Theme env
-    , Element.HasAnimIdPrefix env
-    , Has (Texts.Name Text) env
-    , Glue.HasTexts env, Has (Texts.Code Text) env
-    ) =>
-    Prec -> Annotated Sugar.EntityId # Sugar.Type Name -> m (WithTextPos View)
+makeInternal :: _ => Prec -> Annotated Sugar.EntityId # Sugar.Type Name -> m (WithTextPos View)
 makeInternal parentPrecedence (Ann (Const entityId) tbody) =
     case tbody of
     Sugar.TVar var -> NameView.make var
@@ -284,21 +237,8 @@ makeInternal parentPrecedence (Ann (Const entityId) tbody) =
     where
         animId = WidgetIds.fromEntityId entityId & Widget.toAnimId
 
-make ::
-    ( MonadReader env m, Has Theme env, Spacer.HasStdSpacing env
-    , Element.HasAnimIdPrefix env
-    , Has (Texts.Code Text) env
-    , Has (Texts.Name Text) env
-    , Glue.HasTexts env
-    ) =>
-    Annotated Sugar.EntityId # Sugar.Type Name ->
-    m (WithTextPos View)
+make :: _ => Annotated Sugar.EntityId # Sugar.Type Name -> m (WithTextPos View)
 make t = makeInternal (Prec 0) t & Styled.withColor TextColors.typeTextColor
 
-makeScheme ::
-    ( MonadReader env m, Has Theme env, Spacer.HasStdSpacing env
-    , Element.HasAnimIdPrefix env, Has (Texts.Code Text) env
-    , Glue.HasTexts env, Has (Texts.Name Text) env
-    ) =>
-    Sugar.Scheme Name -> m (WithTextPos View)
+makeScheme :: _ => Sugar.Scheme Name -> m (WithTextPos View)
 makeScheme s = make (s ^. Sugar.schemeType)

--- a/src/Lamdu/GUI/VersionControl.hs
+++ b/src/Lamdu/GUI/VersionControl.hs
@@ -9,11 +9,8 @@ import qualified Data.List.Extended as List
 import qualified Data.Property as Property
 import           GUI.Momentu.Align (TextWidget)
 import qualified GUI.Momentu.Align as Align
-import qualified GUI.Momentu.Element as Element
 import           GUI.Momentu.EventMap (EventMap)
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
-import qualified GUI.Momentu.Hover as Hover
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.MetaKey (MetaKey(..), noMods, toModKey)
 import qualified GUI.Momentu.MetaKey as MetaKey
@@ -36,9 +33,7 @@ import           Revision.Deltum.Transaction (Transaction)
 
 import           Lamdu.Prelude
 
-branchNameFDConfig ::
-    (Has (Texts.Versioning Text) env, Has (Texts.CodeUI Text) env) =>
-    env -> FocusDelegator.Config
+branchNameFDConfig :: _ => env -> FocusDelegator.Config
 branchNameFDConfig txt = FocusDelegator.Config
     { FocusDelegator.focusChildKeys = [MetaKey noMods MetaKey.Key'F2]
     , FocusDelegator.focusChildDoc =
@@ -49,26 +44,20 @@ branchNameFDConfig txt = FocusDelegator.Config
     }
 
 undoEventMap ::
-    (Has (MomentuTexts.Texts Text) env, Has (Texts.Versioning Text) env) =>
-    env -> VersionControl.Config -> Maybe (m GuiState.Update) -> EventMap (m GuiState.Update)
+    _ => env -> VersionControl.Config -> Maybe (m GuiState.Update) -> EventMap (m GuiState.Update)
 undoEventMap env config =
     E.keyPresses (config ^. VersionControl.undoKeys <&> toModKey)
     (E.toDoc env [has . MomentuTexts.edit, has . Texts.undo])
     & foldMap
 
 redoEventMap ::
-    (Has (MomentuTexts.Texts Text) env, Has (Texts.Versioning Text) env) =>
-    env -> VersionControl.Config -> Maybe (m GuiState.Update) -> EventMap (m GuiState.Update)
+    _ => env -> VersionControl.Config -> Maybe (m GuiState.Update) -> EventMap (m GuiState.Update)
 redoEventMap env config =
     E.keyPresses (config ^. VersionControl.redoKeys <&> toModKey)
     (E.toDoc env [has . MomentuTexts.edit, has . Texts.redo])
     & foldMap
 
-eventMap ::
-    ( MonadReader env m, Has (Texts.Versioning Text) env, Has (Texts.CodeUI Text) env
-    , Has (MomentuTexts.Texts Text) env, Applicative f
-    ) =>
-    m (VersionControl.Config -> A.Actions t f -> EventMap (f GuiState.Update))
+eventMap :: _ => m (VersionControl.Config -> A.Actions t f -> EventMap (f GuiState.Update))
 eventMap =
     Lens.view id
     <&> \env config actions ->
@@ -93,13 +82,7 @@ branchTextEditId :: Branch t -> Widget.Id
 branchTextEditId = (`Widget.joinId` ["textedit"]) . branchDelegatorId
 
 makeBranchSelector ::
-    ( MonadReader env mr, Monad n, GuiState.HasCursor env, TextEdit.Deps env
-    , Applicative mw, Has Hover.Style env, Element.HasAnimIdPrefix env
-    , Has VersionControl.Config env, Has VersionControl.Theme env
-    , Has (Texts.Versioning Text) env, Has (Texts.CodeUI Text) env
-    , Has (Choice.Texts Text) env
-    , Has (Glue.Texts Text) env
-    ) =>
+    _ =>
     (forall a. Transaction n a -> mw a) ->
     (forall a. Transaction n a -> mr a) ->
     A.Actions n mw -> mr (TextWidget mw)

--- a/src/Lamdu/GUI/Wrap.hs
+++ b/src/Lamdu/GUI/Wrap.hs
@@ -7,7 +7,6 @@ module Lamdu.GUI.Wrap
 
 import qualified Control.Lens as Lens
 import qualified GUI.Momentu.EventMap as E
-import qualified GUI.Momentu.Glue as Glue
 import qualified GUI.Momentu.I18N as MomentuTexts
 import           GUI.Momentu.Responsive (Responsive(..))
 import qualified GUI.Momentu.State as GuiState
@@ -15,28 +14,18 @@ import           GUI.Momentu.Widget (Widget)
 import qualified GUI.Momentu.Widget as Widget
 import           GUI.Momentu.Widget.Id (subId)
 import qualified GUI.Momentu.Widgets.FocusDelegator as FocusDelegator
-import           Lamdu.Config (Config)
 import qualified Lamdu.Config as Config
 import qualified Lamdu.GUI.Expr.EventMap as ExprEventMap
 import           Lamdu.GUI.Annotation (maybeAddAnnotationPl)
 import           Lamdu.GUI.Monad (GuiM)
 import qualified Lamdu.GUI.Types as ExprGui
 import qualified Lamdu.GUI.WidgetIds as WidgetIds
-import qualified Lamdu.I18N.Code as Texts
-import qualified Lamdu.I18N.CodeUI as Texts
-import qualified Lamdu.I18N.Definitions as Texts
-import qualified Lamdu.I18N.Name as Texts
 import qualified Lamdu.I18N.Navigation as Texts
 import qualified Lamdu.Sugar.Types as Sugar
 
 import           Lamdu.Prelude
 
-parentExprFDConfig ::
-    ( MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    m FocusDelegator.Config
+parentExprFDConfig :: _ => m FocusDelegator.Config
 parentExprFDConfig =
     Lens.view id <&>
     \env ->
@@ -51,15 +40,7 @@ parentExprFDConfig =
     , FocusDelegator.focusParentDoc = doc Texts.leaveSubexpression
     }
 
-stdWrap ::
-    ( Monad i, Monad o
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Glue.HasTexts env
-    ) =>
-    ExprGui.Payload i o -> GuiM env i o (Responsive o) -> GuiM env i o (Responsive o)
+stdWrap :: _ => ExprGui.Payload i o -> GuiM env i o (Responsive o) -> GuiM env i o (Responsive o)
 stdWrap pl act =
     act
     >>> (takeFocusIfNeeded pl <&> (Widget.widget %~))
@@ -68,28 +49,12 @@ stdWrap pl act =
     where
         a >>> f = f <*> a
 
-parentDelegator ::
-    ( HasCallStack, MonadReader env m, Has Config env
-    , Has (MomentuTexts.Texts Text) env
-    , Has (Texts.Navigation Text) env
-    , GuiState.HasCursor env
-    , Applicative o
-    ) => Widget.Id ->
-    m (Responsive o -> Responsive o)
+parentDelegator :: _ => Widget.Id -> m (Responsive o -> Responsive o)
 parentDelegator myId =
     FocusDelegator.make <*> parentExprFDConfig
     ?? FocusDelegator.FocusEntryChild ?? myId
 
-stdWrapParentExpr ::
-    ( Monad i, Monad o
-    , Glue.HasTexts env
-    , Has (Texts.Code Text) env
-    , Has (Texts.CodeUI Text) env
-    , Has (Texts.Definitions Text) env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Navigation Text) env
-    ) =>
-    ExprGui.Payload i o -> GuiM env i o (Responsive o) -> GuiM env i o (Responsive o)
+stdWrapParentExpr :: _ => ExprGui.Payload i o -> GuiM env i o (Responsive o) -> GuiM env i o (Responsive o)
 stdWrapParentExpr pl act =
     parentDelegator (WidgetIds.fromExprPayload (pl ^. _1)) <*> act & stdWrap pl
 

--- a/test/Test/Lamdu/Sugar.hs
+++ b/test/Test/Lamdu/Sugar.hs
@@ -7,11 +7,8 @@ import           Control.Monad.Once (OnceT, evalOnceT)
 import           Control.Monad.Transaction (getP)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified GUI.Momentu.Direction as Dir
 import           Hyper
 import           Hyper.Type.Functor
-import qualified Lamdu.Annotations as Annotations
-import qualified Lamdu.Cache as Cache
 import qualified Lamdu.Calc.Term as V
 import qualified Lamdu.Calc.Type as T
 import           Lamdu.Data.Anchors (Code(..))
@@ -19,22 +16,16 @@ import qualified Lamdu.Data.Anchors as Anchors
 import           Lamdu.Data.Db.Layout (ViewM, codeAnchors, runDbTransaction)
 import qualified Lamdu.Data.Definition as Def
 import qualified Lamdu.Data.Tag as Tag
-import qualified Lamdu.Debug as Debug
 import           Lamdu.Expr.IRef (DefI, HRef, iref)
 import qualified Lamdu.Expr.Load as ExprLoad
-import qualified Lamdu.I18N.Code as Texts
-import           Lamdu.I18N.LangId (LangId)
-import qualified Lamdu.I18N.Name as Texts
 import           Lamdu.Name (Name)
 import           Lamdu.Sugar (sugarWorkArea)
-import           Lamdu.Sugar.Config (Config(..))
 import qualified Lamdu.Sugar.Internal.EntityId as EntityId
 import           Lamdu.Sugar.Types as Sugar
 import           Lamdu.VersionControl (runAction)
 import           Revision.Deltum.IRef (IRef(..))
 import           Revision.Deltum.Transaction (Transaction)
 import           Test.Lamdu.Db (withDB)
-import           Test.Lamdu.Env (EvalResults)
 
 import           Test.Lamdu.Prelude
 
@@ -97,7 +88,7 @@ workAreaLowLevelLoad =
     <*> (getP (panes codeAnchors) >>= traverse loadPane)
 
 validate ::
-    (NFData v, NFData t, NFData name, HasCallStack) =>
+    (NFData v, NFData t, NFData name) =>
     WorkArea v name (OnceT (T fa)) (T fb)
     (Sugar.Payload v name (OnceT (T fa)) (T fb), (t, [EntityId])) ->
     T ViewM
@@ -124,16 +115,7 @@ validate workArea
         sugarEntityIdsSet = Set.fromList (sugarEntityIds <&> fst)
 
 convertWorkArea ::
-    ( HasCallStack
-    , Has LangId env
-    , Has (Texts.Name Text) env
-    , Has (Texts.Code Text) env
-    , Has Dir.Layout env
-    , Has Debug.Monitors env
-    , Has EvalResults env
-    , Has Config env
-    , Has Cache.Functions env, Has Annotations.Mode env
-    ) =>
+    _ =>
     env ->
     OnceT (T ViewM)
     ( WorkArea (Annotation (EvaluationScopes Name (OnceT (T ViewM))) Name) Name (OnceT (T ViewM)) (T ViewM)

--- a/test/Tests/Gui.hs
+++ b/test/Tests/Gui.hs
@@ -86,7 +86,7 @@ type WorkArea =
     Name (OnceT (T ViewM)) (T ViewM)
     (Sugar.Payload SugarAnn Name (OnceT (T ViewM)) (T ViewM), ExprGui.GuiPayload)
 
-makeWorkArea :: HasCallStack => Env -> OnceT (T ViewM) WorkArea
+makeWorkArea :: Env -> OnceT (T ViewM) WorkArea
 makeWorkArea env = convertWorkArea env <&> (fmap . fmap) (uncurry ExprGui.GuiPayload)
 
 makeGui ::


### PR DESCRIPTION
This replaces long type contexts with wildcards,
reducing ctxs and imports boilerplate significantly (literally 1.5K lines),
and making things overall easier to read and write,
with the downside being that constraints may propagate freely
all to way up to the top-level consumer side.
This also replaces some instance of trying to use ConstraintKinds to alleviate the same issue.

To me this seems like a nice solution to this mtl-gone-wild problem,
and the feature has been available since GHC 7.10 (2015), see
https://www.schoolofhaskell.com/user/thomasw/new-in-ghc-7-10-partial-type-signatures#extra-constraints-wildcard

On the way of this big mechanic change have also did a little Momentu imports cleanup
(insignificant in the stats).