### PR TITLE
Cleanup: more exact types replace mAddLet action in NodeActions

### DIFF
--- a/src/Lamdu/GUI/Expr/EventMap.hs
+++ b/src/Lamdu/GUI/Expr/EventMap.hs
@@ -120,7 +120,6 @@ actionsEventMap options exprInfo =
         , extractEventMap ?? actions
         , mkReplaceParent
         , actions ^. Sugar.delete & replaceEventMap
-        , actions ^. Sugar.mNewLet & foldMap addLetEventMap
         , actions ^. Sugar.mApply & foldMap applyEventMap
         , makeLiteralEventMap ?? actions ^. Sugar.setToLiteral
         ] <&> const -- throw away EventContext here

--- a/src/Lamdu/GUI/Expr/IfElseEdit.hs
+++ b/src/Lamdu/GUI/Expr/IfElseEdit.hs
@@ -92,11 +92,10 @@ makeElse parentAnimId (Ann (Const pl) (Sugar.SimpleElse expr)) =
     <&> pure
     where
         elseAnimId = parentAnimId <> ["else"]
-makeElse _ (Ann (Const pl) (Sugar.ElseIf content)) =
+makeElse _ (Ann (Const pl) (Sugar.ElseIf (Sugar.ElseIfBody addLet content))) =
     do
         -- TODO: green evaluation backgrounds, "◗"?
-        letEventMap <-
-            foldMap ExprEventMap.addLetEventMap (pl ^. Sugar.plActions . Sugar.mNewLet)
+        letEventMap <- ExprEventMap.addLetEventMap addLet
         (:)
             <$> ( makeIfThen ElseIf animId content
                   <&> Lens.mapped %~ M.weakerEvents letEventMap

--- a/src/Lamdu/Sugar/Annotations.hs
+++ b/src/Lamdu/Sugar/Annotations.hs
@@ -76,6 +76,9 @@ instance MarkBodyAnnotations v m e => MarkAnnotations m (e v n i o) (e (ShowAnno
             (showAnn, newBody) = markBodyAnnotations x
 
 instance Functor m => MarkBodyAnnotations v m Binder where
+    markBodyAnnotations = bBody markBodyAnnotations
+
+instance Functor m => MarkBodyAnnotations v m BinderBody where
     markBodyAnnotations (BinderTerm body) =
         markBodyAnnotations body & _2 %~ BinderTerm
     markBodyAnnotations (BinderLet let_) =
@@ -94,7 +97,7 @@ instance Functor m => MarkBodyAnnotations v m Else where
     markBodyAnnotations (SimpleElse body) = markBodyAnnotations body & _2 %~ SimpleElse . markCaseHandler
     markBodyAnnotations (ElseIf x) =
         ( neverShowAnnotations
-        , morphMap (Proxy @(MarkAnnotations m) #?> markNodeAnnotations) x & ElseIf
+        , x & eIfElse %~ morphMap (Proxy @(MarkAnnotations m) #?> markNodeAnnotations) & ElseIf
         )
 
 instance Functor m => MarkBodyAnnotations v m Function where

--- a/src/Lamdu/Sugar/Convert/Expression/Actions.hs
+++ b/src/Lamdu/Sugar/Convert/Expression/Actions.hs
@@ -152,9 +152,6 @@ makeActions exprPl =
     do
         ext <- mkExtract exprPl
         postProcess <- ConvertM.postProcessAssert
-        outerPos <-
-            Lens.view (ConvertM.scScopeInfo . ConvertM.siMOuter)
-            <&> (^? Lens._Just . ConvertM.osiPos)
         setToLit <- makeSetToLiteral exprPl
         apply <- makeApply stored
         pure NodeActions
@@ -163,7 +160,6 @@ makeActions exprPl =
             , _setToLiteral = setToLit
             , _extract = ext
             , _mReplaceParent = Nothing
-            , _mNewLet = outerPos <&> DataOps.redexWrap <&> fmap EntityId.ofValI
             , _mApply = Just apply
             }
     where
@@ -225,8 +221,8 @@ instance FixReplaceParent (PostfixFunc v name i o) where
 -- TODO: These instances have a repeating pattern
 instance FixReplaceParent (Binder v name i o) where
     fixReplaceParent setToExpr =
-        (hVal . _BinderTerm . typeMismatchPayloads %~ join setToExpr) .
-        ((bodyIndex . Lens.filteredByIndex _BinderTerm . fragmentAnnIndex) <. annotation %@~ setToExpr)
+        (hVal . bBody . _BinderTerm . typeMismatchPayloads %~ join setToExpr) .
+        ((bodyIndex . Lens.filteredByIndex (bBody . _BinderTerm) . fragmentAnnIndex) <. annotation %@~ setToExpr)
 
 instance FixReplaceParent (Term v name i o) where
     fixReplaceParent setToExpr =

--- a/src/Lamdu/Sugar/Convert/Fragment.hs
+++ b/src/Lamdu/Sugar/Convert/Fragment.hs
@@ -214,7 +214,7 @@ makeLocal top arg typ val =
 
 toFragOpt :: Annotated (Payload a m) # Binder v name i o -> Annotated (Payload a m) # FragOpt v name i o
 toFragOpt o =
-    case o ^. hVal of
+    case o ^. hVal . bBody of
     BinderTerm (BodyPostfixApply (PostfixApply a f)) ->
         reverse (f : match a)
         <&> annotation . plActions . detach .~ o ^. annotation . plActions . detach

--- a/src/Lamdu/Sugar/Eval.hs
+++ b/src/Lamdu/Sugar/Eval.hs
@@ -82,6 +82,9 @@ instance AddEval i n Assignment where
     addToBody r i (BodyPlain x) = x & apBody %~ addToBody r i & BodyPlain
 
 instance AddEval i n Binder where
+    addToBody r i = bBody %~ addToBody r i
+
+instance AddEval i n BinderBody where
     addToBody r i (BinderLet x) = addToBody r i x & BinderLet
     addToBody r i (BinderTerm x) = addToBody r i x & BinderTerm
 
@@ -89,7 +92,7 @@ instance AddEval i n Composite
 
 instance AddEval i n Else where
     addToBody r i (SimpleElse x) = addToBody r i x & SimpleElse
-    addToBody r i (ElseIf x) = addToBody r i x & ElseIf
+    addToBody r i (ElseIf x) = x & eIfElse %~ addToBody r i & ElseIf
 
 instance AddEval i n Function where
     addToBody ctx i x@Function{..} =

--- a/src/Lamdu/Sugar/Names/Walk.hs
+++ b/src/Lamdu/Sugar/Names/Walk.hs
@@ -189,6 +189,9 @@ instance ToBody Let where
             pure let_{_lName, _lBody, _lValue}
 
 instance ToBody Binder where
+    toBody = bBody toBody
+
+instance ToBody BinderBody where
     toBody (BinderLet l) = toBody l <&> BinderLet
     toBody (BinderTerm e) = toBody e <&> BinderTerm
 
@@ -339,7 +342,7 @@ instance ToBody Nominal where
 
 instance ToBody Else where
     toBody (SimpleElse x) = toBody x <&> SimpleElse
-    toBody (ElseIf x) = toBody x <&> ElseIf
+    toBody (ElseIf x) = eIfElse toBody x <&> ElseIf
 
 instance ToBody IfElse where
     toBody (IfElse i t e) = IfElse <$> toExpression i <*> toExpression t <*> toExpression e

--- a/src/Lamdu/Sugar/OrderTags.hs
+++ b/src/Lamdu/Sugar/OrderTags.hs
@@ -152,6 +152,9 @@ instance (MonadTransaction m o, MonadTransaction m i) => Order i (Sugar.Assignme
     order (Sugar.BodyFunction x) = order x <&> Sugar.BodyFunction
 
 instance (MonadTransaction m o, MonadTransaction m i) => Order i (Sugar.Binder v name i o) where
+    order = Sugar.bBody order
+
+instance (MonadTransaction m o, MonadTransaction m i) => Order i (Sugar.BinderBody v name i o) where
     order (Sugar.BinderTerm x) = order x <&> Sugar.BinderTerm
     order (Sugar.BinderLet x) = order x <&> Sugar.BinderLet
 

--- a/src/Lamdu/Sugar/Parens.hs
+++ b/src/Lamdu/Sugar/Parens.hs
@@ -80,6 +80,9 @@ instance HasPrecedence name => AddParens (Assignment v name i o) where
     parenInfo _ (BodyFunction x) = (False, unambiguousBody x & BodyFunction)
 
 instance HasPrecedence name => AddParens (Binder v name i o) where
+    parenInfo p = bBody (parenInfo p)
+
+instance HasPrecedence name => AddParens (BinderBody v name i o) where
     parenInfo parentPrec (BinderTerm x) = parenInfo parentPrec x & _2 %~ BinderTerm
     parenInfo _ (BinderLet x) = (False, unambiguousBody x & BinderLet)
 

--- a/src/Lamdu/Sugar/Types/Parts.hs
+++ b/src/Lamdu/Sugar/Types/Parts.hs
@@ -10,8 +10,7 @@ module Lamdu.Sugar.Types.Parts
     -- Node actions
     , DetachAction(..), _FragmentedAlready, _DetachAction
     , Delete(..), _SetToHole, _Delete, _CannotDelete
-    , NodeActions(..)
-        , detach, delete, setToLiteral, extract, mReplaceParent, mNewLet, mApply
+    , NodeActions(..), detach, delete, setToLiteral, extract, mReplaceParent, mApply
     , -- Let
       ExtractDestination(..)
     , -- TaggedList
@@ -102,7 +101,6 @@ data NodeActions o = NodeActions
     , _setToLiteral :: Literal Identity -> o EntityId
     , _extract :: o ExtractDestination
     , _mReplaceParent :: Maybe (o EntityId)
-    , _mNewLet :: Maybe (o EntityId)
     , _mApply :: Maybe (o EntityId)
     } deriving Generic
 

--- a/test/Test/Lamdu/Instances.hs
+++ b/test/Test/Lamdu/Instances.hs
@@ -110,11 +110,11 @@ instance Eq (Sugar.TagPane f) where
     [ ''Sugar.Annotation, ''Sugar.BinderParams, ''Sugar.CompositeFields
     , ''Sugar.DefinitionOutdatedType, ''Sugar.FuncParam, ''Sugar.Type
     , ''Sugar.ResBody, ''Sugar.ResInject, ''Sugar.ResRecord, ''Sugar.ResTable
-    , ''Sugar.AnnotatedArg, ''Sugar.AssignPlain, ''Sugar.Assignment, ''Sugar.Binder
+    , ''Sugar.AnnotatedArg, ''Sugar.AssignPlain, ''Sugar.Assignment, ''Sugar.Binder, ''Sugar.BinderBody
     , ''Sugar.Composite, ''Sugar.CompositeTail, ''Sugar.OptionalTag
     , ''Sugar.TaggedItem, ''Sugar.TaggedSwappableItem, ''Sugar.TaggedList, ''Sugar.TaggedListBody
     , ''Sugar.Definition , ''Sugar.DefinitionBody, ''Sugar.DefinitionExpression
-    , ''Sugar.Else, ''Sugar.Fragment, ''Sugar.Function, ''Sugar.IfElse
+    , ''Sugar.Else, ''Sugar.ElseIfBody, ''Sugar.Fragment, ''Sugar.Function, ''Sugar.IfElse
     , ''Sugar.LabeledApply, ''Sugar.Lambda, ''Sugar.Let
     , ''Sugar.Nominal, ''Sugar.NullaryInject, ''Sugar.OperatorArgs, ''Sugar.Pane, ''Sugar.PaneBody
     , ''Sugar.PostfixApply, ''Sugar.PostfixFunc, ''Sugar.PunnedVar, ''Sugar.Repl, ''Sugar.Term

--- a/test/Test/Lamdu/SugarStubs.hs
+++ b/test/Test/Lamdu/SugarStubs.hs
@@ -154,11 +154,11 @@ def typ var tag body =
         emptyForalls = T.Types (QVars mempty) (QVars mempty)
 
 repl ::
-    Annotated a # Sugar.Term v name i o ->
-    Sugar.Repl v name i o a
+    Annotated a # Sugar.Term v name i Unit ->
+    Sugar.Repl v name i Unit a
 repl (Ann (Const pl) x) =
     Sugar.Repl
-    { Sugar._replExpr = Ann (Const pl) (Sugar.BinderTerm x)
+    { Sugar._replExpr = Ann (Const pl) (Sugar.Binder Unit (Sugar.BinderTerm x))
     , Sugar._replVarInfo = Sugar.VarGeneric
     , Sugar._replResult = CurAndPrev Nothing Nothing
     }
@@ -176,7 +176,7 @@ funcExpr paramVar paramTag (Ann (Const ba) bx) =
         , Sugar.VarParamInfo (Sugar.OptionalTag (mkTag (Just paramVar) paramTag) Unit)
             (Sugar.AddNext (Identity tagRefReplace)) (Sugar.AddNext (Identity tagRefReplace)) Unit
         )
-    , Sugar._fBody = Ann (Const ba) (Sugar.BinderTerm bx)
+    , Sugar._fBody = Ann (Const ba) (Sugar.Binder Unit (Sugar.BinderTerm bx))
     }
 
 expr ::
@@ -207,7 +207,6 @@ nodeActions =
     , Sugar._setToLiteral = pure Unit
     , Sugar._extract = Unit
     , Sugar._mReplaceParent = Nothing
-    , Sugar._mNewLet = Nothing
     , Sugar._mApply = Nothing
     }
 

--- a/test/Tests/Gui.hs
+++ b/test/Tests/Gui.hs
@@ -74,7 +74,7 @@ test =
 replExpr ::
     Lens.Traversal' (Sugar.WorkArea v name i o a)
     (Sugar.Term v name i o # Annotated a)
-replExpr = Sugar.waRepl . Sugar.replExpr . hVal . Sugar._BinderTerm
+replExpr = Sugar.waRepl . Sugar.replExpr . hVal . Sugar.bBody . Sugar._BinderTerm
 
 wideFocused :: Lens.Traversal' (Responsive f) (Widget.Surrounding -> Widget.Focused (f GuiState.Update))
 wideFocused = Responsive.rWide . Align.tValue . Widget.wState . Widget._StateFocused
@@ -289,8 +289,8 @@ testPunCursor =
     where
         waRec =
             Sugar.waRepl . Sugar.replExpr . hVal
-            . Sugar._BinderLet . Sugar.lBody . hVal
-            . Sugar._BinderTerm . Sugar._BodyRecord
+            . Sugar.bBody . Sugar._BinderLet . Sugar.lBody . hVal
+            . Sugar.bBody . Sugar._BinderTerm . Sugar._BodyRecord
 
 workAreaEq ::
     forall m v.

--- a/test/Tests/Names.hs
+++ b/test/Tests/Names.hs
@@ -125,6 +125,7 @@ workAreaGlobals =
                 , show textCollision, show tagCollision
                 ] & assertString
         trivialBinder =
-            Sugar.AssignPlain Unit (Sugar.BinderTerm (Sugar.BodyLeaf (Sugar.LeafHole (Sugar.Hole mempty))))
+            Sugar.Hole mempty & Sugar.LeafHole & Sugar.BodyLeaf & Sugar.BinderTerm
+            & Sugar.Binder Unit & Sugar.AssignPlain Unit
             & Sugar.BodyPlain
             & Ann (Const Stub.payload)


### PR DESCRIPTION
Before pushing this wanted to get your opinion if this is indeed cleaner.
This just hanged in my todo-list and currently looked like the easiest thing there so did this :)

Commit message:

The types communicate that let items are added in binders and in else-if conditions.

This is a reversal on e1ff32e6 & e22691db34, back to a state we previously had.
Not exactly sure why we switched but this looks cleaner to me currently.