### PR TITLE
Fix wrong link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project aims to create a *next-generation*, *live programming* environment
 that radically improves the programming experience.
 
-See the [Main Page](http://lamdu.org/)
+See the [Main Page](http://www.lamdu.org/)
 
 ## Installation
 


### PR DESCRIPTION
The change made in #231 has broken the link to the Main Page in the README.md.