### PR TITLE
nix: fix darwin framework system deps for haskell.nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,47 @@
       let
         overlays = [
           haskellNix.overlay
+
+          # haskell.nix materialized cabal files often refer to Apple frameworks as
+          # `pkgs."CoreFoundation"`, `pkgs."Cocoa"`, etc. Newer nixpkgs exposes
+          # them under `pkgs.darwin.apple_sdk.frameworks.*`, so we provide aliases.
+          (final: prev:
+            prev.lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+              CoreFoundation = prev.darwin.apple_sdk.frameworks.CoreFoundation;
+              Cocoa = prev.darwin.apple_sdk.frameworks.Cocoa;
+              IOKit = prev.darwin.apple_sdk.frameworks.IOKit;
+              CoreVideo = prev.darwin.apple_sdk.frameworks.CoreVideo;
+              OpenGL = prev.darwin.apple_sdk.frameworks.OpenGL;
+              Security = prev.darwin.apple_sdk.frameworks.Security;
+              Foundation = prev.darwin.apple_sdk.frameworks.Foundation;
+              AppKit = prev.darwin.apple_sdk.frameworks.AppKit;
+              CoreServices = prev.darwin.apple_sdk.frameworks.CoreServices;
+            }
+          )
+
           (final: _prev: {
             Lamdu = final.haskell-nix.hix.project {
               name = "Lamdu";
               src = ./.;
               evalSystem = system;
               compiler-nix-name = "ghc984";
+
+              # nixpkgs no longer provides an AGL framework package, but
+              # haskell.nix still picks it up via bindings-GLFW on darwin.
+              # Override the frameworks list to a known-good set.
+              modules = [
+                ({ pkgs, lib, ... }: {
+                  packages.bindings-GLFW.components.library.frameworks = lib.mkForce (
+                    with pkgs.darwin.apple_sdk.frameworks;
+                    [
+                      Cocoa
+                      IOKit
+                      CoreVideo
+                      OpenGL
+                    ]
+                  );
+                })
+              ];
 
               shell.tools = {
                 cabal = { };


### PR DESCRIPTION
THIS COMMIT AS WELL AS IT'S COMMIT MESSAGE HAS BEEN WRITEN BY AN AI AGENT.
I AM STILL GETTING A HANG OF NIX.

Problem
- `nix build .#Lamdu:exe:lamdu` failed during haskell.nix plan evaluation on Darwin.
- The failure presented as missing system dependencies (frameworks), notably `AGL` and
  `CoreFoundation`.

Root cause
- haskell.nix materialized Cabal files translate `Frameworks: Foo` into a lookup of
  `pkgs."Foo"`.
- In the nixpkgs revision pinned by this flake, Apple frameworks are exposed under
  `pkgs.darwin.apple_sdk.frameworks.*`, so `pkgs."CoreFoundation"` (etc.) is not present.
- `AGL` is no longer provided by nixpkgs, but could still be referenced by older GLFW bindings.

Fix
- Add a Darwin-only overlay that aliases common Apple frameworks into the top-level `pkgs`
  namespace (e.g. `pkgs.CoreFoundation = pkgs.darwin.apple_sdk.frameworks.CoreFoundation`).
- Override `packages.bindings-GLFW.components.library.frameworks` to a known-good set and
  drop `AGL`.

Result
- `nix build .#Lamdu:exe:lamdu` evaluates and builds successfully on Darwin.

Co-Authored-By: Oz <oz-agent@warp.dev>
