### PR TITLE
nix: fix darwin frameworks + GLFW native API for haskell.nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,56 @@
       let
         overlays = [
           haskellNix.overlay
+
+          # haskell.nix materialized cabal files often refer to Apple frameworks as
+          # `pkgs."CoreFoundation"`, `pkgs."Cocoa"`, etc. Newer nixpkgs exposes
+          # them under `pkgs.darwin.apple_sdk.frameworks.*`, so we provide aliases.
+          (final: prev:
+            prev.lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+              CoreFoundation = prev.darwin.apple_sdk.frameworks.CoreFoundation;
+              Cocoa = prev.darwin.apple_sdk.frameworks.Cocoa;
+              IOKit = prev.darwin.apple_sdk.frameworks.IOKit;
+              CoreVideo = prev.darwin.apple_sdk.frameworks.CoreVideo;
+              OpenGL = prev.darwin.apple_sdk.frameworks.OpenGL;
+              Security = prev.darwin.apple_sdk.frameworks.Security;
+              Foundation = prev.darwin.apple_sdk.frameworks.Foundation;
+              AppKit = prev.darwin.apple_sdk.frameworks.AppKit;
+              CoreServices = prev.darwin.apple_sdk.frameworks.CoreServices;
+            }
+          )
+
           (final: _prev: {
             Lamdu = final.haskell-nix.hix.project {
               name = "Lamdu";
               src = ./.;
               evalSystem = system;
               compiler-nix-name = "ghc984";
+
+              # On Darwin, nixpkgs no longer provides an `AGL` framework package.
+              # bindings-GLFW's cabal file still references it, so we override the
+              # framework list to drop AGL.
+              #
+              # Also: Lamdu uses GLFW-b which depends on bindings-GLFW. Lamdu needs
+              # `glfwGetCocoaWindow` from the glfw3native API, which bindings-GLFW
+              # only exposes when built with the `ExposeNative` flag.
+              modules = [
+                ({ pkgs, lib, ... }: {
+                  # Cabal flag `ExposeNative` is represented as `exposenative` in
+                  # haskell.nix materialized package definitions.
+                  packages."bindings-GLFW".flags.exposenative = lib.mkForce true;
+
+                  packages."bindings-GLFW".components.library.frameworks = lib.mkForce (
+                    with pkgs.darwin.apple_sdk.frameworks;
+                    [
+                      Cocoa
+                      IOKit
+                      CoreFoundation
+                      CoreVideo
+                      OpenGL
+                    ]
+                  );
+                })
+              ];
 
               shell.tools = {
                 cabal = { };


### PR DESCRIPTION
THIS PATCH AS WELL AS THE REST OF THIS COMMIT MESSAGE WAS WRITEN BY AN AI AGENT, I AM TESTING OUT AGENT DRIVEN DEVELOPMENT AS WELL AS STARTING TO LEARN NIX. I was interested in your project and wanted to try out lambu.

---
Problem
- `nix build .#Lamdu:exe:lamdu` failed on Darwin during haskell.nix plan evaluation due to
  missing framework system dependencies (e.g. `CoreFoundation`, `AGL`).
- After fixing evaluation/build, `nix run .#Lamdu:exe:lamdu` still aborted at runtime on
  Darwin with:
  `c'glfwGetCocoaWindow undefined! -- Did you use the wrong glfw3native API?`

Root cause
- haskell.nix materialized cabal expressions often translate `Frameworks: Foo` into a lookup
  of `pkgs."Foo"`.
- In the nixpkgs revision pinned by this flake, Apple frameworks live under
  `pkgs.darwin.apple_sdk.frameworks.*`, so the expected top-level attributes are missing.
- nixpkgs no longer provides an `AGL` framework package, but older GLFW bindings still
  reference it.
- Lamdu (via GLFW-b/bindings-GLFW) requires the glfw3native Cocoa accessors
  (`glfwGetCocoaWindow`). bindings-GLFW only enables those bindings when built with the
  Cabal flag `ExposeNative` (materialized as `exposenative`).

Fix
- Add a Darwin-only overlay that aliases common Apple frameworks into the top-level `pkgs`
  namespace (e.g. `pkgs.CoreFoundation = pkgs.darwin.apple_sdk.frameworks.CoreFoundation`).
- Override bindings-GLFW's `frameworks` list to drop `AGL`.
- Force-enable bindings-GLFW's `exposenative` Cabal flag on Darwin so the glfw3native API is
  available at runtime.

Verification
- `nix build .#Lamdu:exe:lamdu`
- `nix run .#Lamdu:exe:lamdu`

Co-Authored-By: Oz <oz-agent@warp.dev>
